### PR TITLE
fix for exceeding the maximum length of discord embeds

### DIFF
--- a/providers/bitbucket.js
+++ b/providers/bitbucket.js
@@ -25,7 +25,7 @@ module.exports = {
                     icon_url: body.actor.links.avatar.href,
                     url: baseLink + body.actor.username
                 };
-                for (let i = 0; i < body.push.changes.length; i++) {
+                for (let i = 0; (i < body.push.changes.length && i <4); i++) {
                     let change = body.push.changes[i];
                     project.branch = (change.old !== null) ? change.old.name : change.new.name;
                     project.commits = change.commits;

--- a/providers/bitbucket.js
+++ b/providers/bitbucket.js
@@ -30,19 +30,26 @@ module.exports = {
                     project.branch = (change.old !== null) ? change.old.name : change.new.name;
                     project.commits = change.commits;
 
-                    let commits = "";
+                    let commits = [];
                     for (let j = 0; j < project.commits.length; j++) {
                         let commit = project.commits[j];
                         let message = (commit.message.length > 50) ? commit.message.substring(0, 47) + "..." : commit.message;
-                        let author = (typeof commit.author.user !== "undefined") ? " - " + commit.author.user.display_name : "";
-                        commits = commits + "[`" + commit.hash.substring(0, 7) + "`](" + commit.links.html.href + ") " + message.replace(/\n/g, " ").replace(/\r/g, " ") + author + "\n";
+                        let author = (typeof commit.author.user !== "undefined") ? commit.author.user.display_name : "Unknown";
+
+                        commits.push({
+                            name: "Commit from " + author,
+                            value: "(" + "[`" + commit.hash.substring(0, 7) + "`](" + commit.links.html.href + ")" + ")" + message.replace(/\n/g, " ").replace(/\r/g, " "),
+                            inline: false
+                        });
+                        //commits = commits + "[`" + commit.hash.substring(0, 7) + "`](" + commit.links.html.href + ") " + message.replace(/\n/g, " ").replace(/\r/g, " ") + author + "\n";
                     }
 
                     discordPayload.addEmbed({
                         title: "[" + project.name + ":" + project.branch + "] " + project.commits.length + " commit" + ((project.commits.length > 1) ? "s" : ""),
                         url: project.url,
                         author: user,
-                        description: commits
+                        fields: commits
+                        //description: commits
                     });
                 }
                 break;
@@ -96,7 +103,7 @@ module.exports = {
                     author: user,
                     title: "Wrote a comment to commit " + body.commit.hash.substring(0, 7) + " on " + body.repository.name,
                     url: baseLink + body.repository.full_name + "/commits/" + body.commit.hash,
-                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 100) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 97) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
+                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1021) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
                 });
                 break;
             case "repo:commit_status_created":
@@ -168,7 +175,7 @@ module.exports = {
                     author: user,
                     title: "Wrote a comment to Issue #" + body.issue.id + " on " + body.repository.name,
                     url: baseLink + body.repository.full_name + "/issues/" + body.issue.id,
-                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 100) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 97) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
+                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1021) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
                 });
                 break;
             case "pullrequest:created":

--- a/providers/bitbucket.js
+++ b/providers/bitbucket.js
@@ -33,7 +33,7 @@ module.exports = {
                     let commits = [];
                     for (let j = 0; j < project.commits.length; j++) {
                         let commit = project.commits[j];
-                        let message = (commit.message.length > 256) ? commit.message.substring(0, 253) + "..." : commit.message;
+                        let message = (commit.message.length > 256) ? commit.message.substring(0, 255) + "\u2026" : commit.message;
                         let author = (typeof commit.author.user !== "undefined") ? commit.author.user.display_name : "Unknown";
 
                         commits.push({
@@ -103,7 +103,7 @@ module.exports = {
                     author: user,
                     title: "Wrote a comment to commit " + body.commit.hash.substring(0, 7) + " on " + body.repository.name,
                     url: baseLink + body.repository.full_name + "/commits/" + body.commit.hash,
-                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1021) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
+                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1023) + "\u2026" : body.comment.content.html.replace(/<.*?>/g, '')
                 });
                 break;
             case "repo:commit_status_created":
@@ -175,7 +175,7 @@ module.exports = {
                     author: user,
                     title: "Wrote a comment to Issue #" + body.issue.id + " on " + body.repository.name,
                     url: baseLink + body.repository.full_name + "/issues/" + body.issue.id,
-                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1021) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
+                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1023) + "\u2026" : body.comment.content.html.replace(/<.*?>/g, '')
                 });
                 break;
             case "pullrequest:created":
@@ -284,7 +284,7 @@ module.exports = {
                     author: user,
                     title: "Wrote a comment to pull request #" + body.pullrequest.id + " on " + body.repository.name,
                     url: baseLink + body.repository.full_name + "/pull-requests/" + body.pullrequest.id,
-                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 100) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 97) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
+                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1023) + "\u2026" : body.comment.content.html.replace(/<.*?>/g, '')
                 });
                 break;
             case "pullrequest:comment_updated":
@@ -298,7 +298,7 @@ module.exports = {
                     author: user,
                     title: "Updated a comment at pull request #" + body.pullrequest.id + " on " + body.repository.name,
                     url: baseLink + body.repository.full_name + "/pull-requests/" + body.pullrequest.id,
-                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 100) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 97) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
+                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1023) + "\u2026" : body.comment.content.html.replace(/<.*?>/g, '')
                 });
                 break;
             case "pullrequest:comment_deleted":
@@ -312,7 +312,7 @@ module.exports = {
                     author: user,
                     title: "Deleted a comment at pull request #" + body.pullrequest.id + " on " + body.repository.name,
                     url: baseLink + body.repository.full_name + "/pull-requests/" + body.pullrequest.id,
-                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 100) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 97) + "..." : body.comment.content.html.replace(/<.*?>/g, '')
+                    description: (body.comment.content.html.replace(/<.*?>/g, '').length > 1024) ? body.comment.content.html.replace(/<.*?>/g, '').substring(0, 1023) + "\u2026" : body.comment.content.html.replace(/<.*?>/g, '')
                 });
                 break;
         }

--- a/providers/bitbucket.js
+++ b/providers/bitbucket.js
@@ -33,7 +33,7 @@ module.exports = {
                     let commits = [];
                     for (let j = 0; j < project.commits.length; j++) {
                         let commit = project.commits[j];
-                        let message = (commit.message.length > 50) ? commit.message.substring(0, 47) + "..." : commit.message;
+                        let message = (commit.message.length > 256) ? commit.message.substring(0, 253) + "..." : commit.message;
                         let author = (typeof commit.author.user !== "undefined") ? commit.author.user.display_name : "Unknown";
 
                         commits.push({

--- a/providers/gitlab.js
+++ b/providers/gitlab.js
@@ -25,7 +25,7 @@ module.exports = {
                 let commits = [];
                 for (let i = 0; (i < project.commits.length && i < 4); i++) {
                     const commit = project.commits[i];
-                    const message = (commit.message.length > 256) ? commit.message.substring(0, 253) + "..." : commit.message;
+                    const message = (commit.message.length > 256) ? commit.message.substring(0, 255) + "\u2026" : commit.message;
 
                     commits.push({
                         name: "Commit from " + commit.author.name,
@@ -67,7 +67,7 @@ module.exports = {
                             name: body.user_name,
                             icon_url: body.user_avatar
                         },
-                        description: (typeof body.message !== 'undefined') ? ((body.message.length > 1024) ? body.message.substring(0, 1021) + "..." : body.message) : ''
+                        description: (typeof body.message !== 'undefined') ? ((body.message.length > 1024) ? body.message.substring(0, 1023) + "\u2026" : body.message) : ''
                     });
                 } else {
                     discordPayload.addEmbed({
@@ -77,7 +77,7 @@ module.exports = {
                             name: body.user_name,
                             icon_url: body.user_avatar
                         },
-                        description: (typeof body.message !== 'undefined') ? ((body.message.length > 1024) ? body.message.substring(0, 1021) + "..." : body.message) : ''
+                        description: (typeof body.message !== 'undefined') ? ((body.message.length > 1024) ? body.message.substring(0, 1023) + "\u2026" : body.message) : ''
                     });
                 }
                 break;
@@ -100,7 +100,7 @@ module.exports = {
                     fields: [
                         {
                             name: body.object_attributes.title,
-                            value: (body.object_attributes.description.length > 1024) ? body.object_attributes.description.substring(0, 1021) + "..." : body.object_attributes.description
+                            value: (body.object_attributes.description.length > 1024) ? body.object_attributes.description.substring(0, 1023) + "\u2026" : body.object_attributes.description
                         }
                     ]
                 });
@@ -130,7 +130,7 @@ module.exports = {
                         name: body.user.name,
                         icon_url: body.user.avatar_url
                     },
-                    description: (body.object_attributes.note.length > 2048) ? body.object_attributes.note.substring(0, 2045) + "..." : body.object_attributes.note
+                    description: (body.object_attributes.note.length > 2048) ? body.object_attributes.note.substring(0, 2047) + "\u2026" : body.object_attributes.note
                 });
                 break;
 
@@ -153,7 +153,7 @@ module.exports = {
                     fields: [
                         {
                             name: body.object_attributes.title,
-                            value: (body.object_attributes.description.length > 1024) ? body.object_attributes.description.substring(0, 1021) + "..." : body.object_attributes.description
+                            value: (body.object_attributes.description.length > 1024) ? body.object_attributes.description.substring(0, 1023) + "\u2026" : body.object_attributes.description
                         }
                     ]
                 });
@@ -173,7 +173,7 @@ module.exports = {
                         name: body.user.name,
                         icon_url: body.user.avatar_url
                     },
-                    description: (typeof body.object_attributes.message !== 'undefined' ) ? (body.object_attributes.message.length > 2048) ? body.object_attributes.message.substring(0, 2045) + "..." : body.object_attributes.message : ''
+                    description: (typeof body.object_attributes.message !== 'undefined' ) ? (body.object_attributes.message.length > 2048) ? body.object_attributes.message.substring(0, 2047) + "\u2026" : body.object_attributes.message : ''
                 });
                 break;
 

--- a/providers/gitlab.js
+++ b/providers/gitlab.js
@@ -22,11 +22,17 @@ module.exports = {
                     commits: body.commits
                 };
 
-                let commits = "";
-                for (let i = 0; i < project.commits.length; i++) {
+                let commits = [];
+                for (let i = 0; (i < project.commits.length && i < 4); i++) {
                     const commit = project.commits[i];
-                    const message = (commit.message.length > 50) ? commit.message.substring(0, 47) + "..." : commit.message;
-                    commits = commits + commit.author.name + " - (" + "[`" + commit.id.substring(0, 7) + "`](" + commit.url + ")" + ") " + message.replace(/\n/g, " ").replace(/\r/g, " ") + "\n";
+                    const message = (commit.message.length > 256) ? commit.message.substring(0, 253) + "..." : commit.message;
+
+                    commits.push({
+                        name: "Commit from " + commit.author.name,
+                        value: "(" + "[`" + commit.id.substring(0, 7) + "`](" + commit.url + ")" + ")" + message.replace(/\n/g, " ").replace(/\r/g, " "),
+                        inline: false
+                    });
+                    //commits = commits + commit.author.name + " - (" + "[`" + commit.id.substring(0, 7) + "`](" + commit.url + ")" + ") " + message.replace(/\n/g, " ").replace(/\r/g, " ") + "\n";
                 }
 
                 discordPayload.addEmbed({
@@ -36,7 +42,8 @@ module.exports = {
                         name: body.user_name,
                         icon_url: body.user_avatar
                     },
-                    description: commits
+                    fields: commits
+                    //description: commits
                 });
                 break;
 
@@ -60,7 +67,7 @@ module.exports = {
                             name: body.user_name,
                             icon_url: body.user_avatar
                         },
-                        description: (typeof body.message !== 'undefined') ? body.message : ''
+                        description: (typeof body.message !== 'undefined') ? ((body.message.length > 1024) ? body.message.substring(0, 1021) + "..." : body.message) : ''
                     });
                 } else {
                     discordPayload.addEmbed({
@@ -70,7 +77,7 @@ module.exports = {
                             name: body.user_name,
                             icon_url: body.user_avatar
                         },
-                        description: (typeof body.message !== 'undefined') ? body.message : ''
+                        description: (typeof body.message !== 'undefined') ? ((body.message.length > 1024) ? body.message.substring(0, 1021) + "..." : body.message) : ''
                     });
                 }
                 break;
@@ -93,7 +100,7 @@ module.exports = {
                     fields: [
                         {
                             name: body.object_attributes.title,
-                            value: (body.object_attributes.description.length > 200) ? body.object_attributes.description.substring(0, 197) + "..." : body.object_attributes.description
+                            value: (body.object_attributes.description.length > 1024) ? body.object_attributes.description.substring(0, 1021) + "..." : body.object_attributes.description
                         }
                     ]
                 });
@@ -101,7 +108,7 @@ module.exports = {
 
             case "note":
                 let type = null;
-                switch(body.object_attributes.noteable_type){
+                switch (body.object_attributes.noteable_type) {
                     case "Commit":
                         type = "commit (" + body.commit.id.substring(0, 7) + ")";
                         break;
@@ -123,7 +130,7 @@ module.exports = {
                         name: body.user.name,
                         icon_url: body.user.avatar_url
                     },
-                    description: (body.object_attributes.note.length > 50) ? body.object_attributes.note.substring(0, 47) + "..." : body.object_attributes.note
+                    description: (body.object_attributes.note.length > 2048) ? body.object_attributes.note.substring(0, 2045) + "..." : body.object_attributes.note
                 });
                 break;
 
@@ -146,7 +153,7 @@ module.exports = {
                     fields: [
                         {
                             name: body.object_attributes.title,
-                            value: (body.object_attributes.description.length > 200) ? body.object_attributes.description.substring(0, 197) + "..." : body.object_attributes.description
+                            value: (body.object_attributes.description.length > 1024) ? body.object_attributes.description.substring(0, 1021) + "..." : body.object_attributes.description
                         }
                     ]
                 });
@@ -166,7 +173,7 @@ module.exports = {
                         name: body.user.name,
                         icon_url: body.user.avatar_url
                     },
-                    description: (typeof body.object_attributes.message !== 'undefined' ) ? (body.object_attributes.message.length > 200) ? body.object_attributes.message.substring(0, 197) + "..." : body.object_attributes.message : ''
+                    description: (typeof body.object_attributes.message !== 'undefined' ) ? (body.object_attributes.message.length > 2048) ? body.object_attributes.message.substring(0, 2045) + "..." : body.object_attributes.message : ''
                 });
                 break;
 


### PR DESCRIPTION
That should hopefully help to not exceed the maximum length of the discord embeds as described in #22 

What changed?
- showing max. 4 commits for GitLab and BitBucket
   - shorting commit messages to a maximum of 256 characters.
- limiting some other strings of GitLab and BitBucket events