### PR TITLE
Fixes for Node.js 8.6.x

### DIFF
--- a/server.js
+++ b/server.js
@@ -77,7 +77,13 @@ app.post("/api/webhooks/:webhookID/:webhookSecret/:from", async function (req, r
 
     if (typeof providers[provider] !== 'undefined') {
         const instance = new providers[provider]();
-        discordPayload = await instance.parse(req);
+        try {
+            discordPayload = await instance.parse(req);
+        } catch (error) {
+            console.log('Error during parse:', error);
+            res.sendStatus(500);
+            //Winston doesn't log errors?? winston.error(error)
+        }
     } else {
         winston.error('Unknown provider "' + provider + '"');
     }


### PR DESCRIPTION
I am running node.js 8.6.x and it appears that unhandled promise rejections will soon crash the application. On encountering an unexpected error, the following warnings are displayed:

* `node:18784) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'replace' of undefined`
* `(node:18784) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`

![](https://i.gyazo.com/f7a9e954b67b2957b3e0f3c15f66c254.png)

The following PR corrects this and the warnings are no longer shown. If an error occurs while parsing, the error is caught and printed out. From there, an error code of 500 will be returned, as an internal error has ocurred with one of the providers.

I could not get the error to print using winston, so I just used console.log().