### PR TITLE
Adding log to BaseProvider in order to monitor recent unexpected crashes

### DIFF
--- a/util/BaseProvider.js
+++ b/util/BaseProvider.js
@@ -17,6 +17,7 @@ class BaseProvider {
         type = BaseProvider.formatType(type);
 
         if (typeof this[type] !== 'undefined') {
+            console.log('[' + (new Date()).toUTCString() + '] Calling ' + type + '() in ' + this.constructor.name + ' provider.')
             await this[type]();
         }
 


### PR DESCRIPTION
Logs the time, method, and provider each time a parse job is started. Intended to help us identify potential issues which cause the program to crash.

Example output:

![image](https://user-images.githubusercontent.com/9703873/32021945-e3e21afc-b9a2-11e7-8c54-77c656c1136e.png)

for #55 