### PR TITLE
Updating material-components to ^0.25.0

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,7 +7,7 @@
     <title>skyhook</title>
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.28.0/dist/material-components-web.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.29.0/dist/material-components-web.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
@@ -74,7 +74,7 @@
     </div>
     </body>
 </main>
-<script src="https://unpkg.com/material-components-web@0.28.0/dist/material-components-web.min.js"></script>
+<script src="https://unpkg.com/material-components-web@0.29.0/dist/material-components-web.min.js"></script>
 <script src="./copyToClipboard.min.js"></script>
 <script src="https://code.jquery.com/jquery-2.2.1.min.js"
         integrity="sha256-gvQgAFzTH6trSrAWoH1iPo9Xc96QxSZ3feW6kem+O00="

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,7 +7,7 @@
     <title>skyhook</title>
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.25.0/dist/material-components-web.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.28.0/dist/material-components-web.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
@@ -33,12 +33,11 @@
         </p>
 
         <div class="mdc-form-field">
-            <div class="mdc-text-field mdc-text-field--multiline mdc-text-field--fullwidth"
-                 data-mdc-auto-init="MDCTextField">
+            <div class="mdc-text-field mdc-text-field--multiline"
+                 data-mdc-auto-init="MDCTextField" style="width: 100%;">
                 <input id="url" type="text" class="mdc-text-field__input">
-                <label for="url" class="mdc-text-field__label">
-                    Discord Webhook URL
-                </label>
+                <label for="url" class="mdc-text-field__label">Discord Webhook URL</label>
+                <div class="mdc-text-field__bottom-line"></div>
             </div>
         </div>
 
@@ -75,7 +74,7 @@
     </div>
     </body>
 </main>
-<script src="https://unpkg.com/material-components-web@0.25.0/dist/material-components-web.min.js"></script>
+<script src="https://unpkg.com/material-components-web@0.28.0/dist/material-components-web.min.js"></script>
 <script src="./copyToClipboard.min.js"></script>
 <script src="https://code.jquery.com/jquery-2.2.1.min.js"
         integrity="sha256-gvQgAFzTH6trSrAWoH1iPo9Xc96QxSZ3feW6kem+O00="

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,7 +7,7 @@
     <title>skyhook</title>
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.8.0/dist/material-components-web.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.25.0/dist/material-components-web.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
@@ -31,12 +31,12 @@
             URL generated,
             you can pass it along to the provider you selected.
         </p>
-        <br/>
+
         <div class="mdc-form-field">
-            <div class="mdc-textfield mdc-textfield--multiline mdc-textfield--fullwidth"
-                 data-mdc-auto-init="MDCTextfield">
-                <input id="url" type="text" class="mdc-textfield__input">
-                <label for="url" class="mdc-textfield__label">
+            <div class="mdc-text-field mdc-text-field--multiline mdc-text-field--fullwidth"
+                 data-mdc-auto-init="MDCTextField">
+                <input id="url" type="text" class="mdc-text-field__input">
+                <label for="url" class="mdc-text-field__label">
                     Discord Webhook URL
                 </label>
             </div>
@@ -75,7 +75,7 @@
     </div>
     </body>
 </main>
-<script src="https://unpkg.com/material-components-web@0.8.0/dist/material-components-web.min.js"></script>
+<script src="https://unpkg.com/material-components-web@0.25.0/dist/material-components-web.min.js"></script>
 <script src="./copyToClipboard.min.js"></script>
 <script src="https://code.jquery.com/jquery-2.2.1.min.js"
         integrity="sha256-gvQgAFzTH6trSrAWoH1iPo9Xc96QxSZ3feW6kem+O00="


### PR DESCRIPTION
~### PR is not ready to merge, waiting on issues to be resolved in material-components.~
### Ready to merge once reviewed.

This PR will fix the compatability issues with the latest version of material-components. The latest version itself has some errors, though. The main one is that the text-field does not apply the theme color when it is focused. Another thing is that in the latest version the size of the label text in the text-field seems to have been reduced. I'm not sure if this is intended. I would recommend holding off on this PR until material-components resolves these issues. It's likely that these fixes will come in versions after 0.25.0, therefore the version will need to be re-pinned at that time.

Optionally we can add an extra feature to this, adding the following html into the last line of the `mdc-text-field mdc-text-field--multiline mdc-text-field--fullwidth` div. The style can be modified, it's just basically where the animation originates from. A few other minor changes would be needed, but I can worry about those if we choose to implement this.

```HTML
<div class="mdc-text-field__bottom-line" style="transform-origin: 49.14813232421875px center"></div>
```

### Here are some visuals of the issues/suggestions:

**Textfield size/color issue:**

![](https://i.gyazo.com/ee7c47f79909b9ded0b9267b9354300f.gif)

*Compared to v0.8.0*

![](https://i.gyazo.com/93f692680e2258e57bf08de2e1fc1039.gif)

**Bottom-line insert:**

![](https://i.gyazo.com/4555ee38250dd205521bbc00b84b275c.gif)

---

Feel free to commit to this PR as updates come along.

**Related issues:**

  * Commit451/skyhook#71 
  * Commit451/skyhook#69 
  * material-components/material-components-web#1435
  * material-components/material-components-web#1582

**Text Field demo page:**

https://material-components-web.appspot.com/text-field.html