### PR TITLE
Additional info on circleci (Fixes #76)

### DIFF
--- a/providers/circleci.js
+++ b/providers/circleci.js
@@ -9,6 +9,8 @@ class CircleCi extends BaseProvider {
     }
 
     async parseData(req) {
+        let subject = this.body.payload.subject.length > 48 ? `${this.body.payload.subject.substring(0,48)}\u2026` : this.body.payload.subject;
+
         this.payload.setEmbedColor(0x343433);
         this.payload.addEmbed({
             title: `Build #${this.body.payload.build_num}`,
@@ -17,7 +19,7 @@ class CircleCi extends BaseProvider {
                 name: `${this.body.payload.reponame}:${this.body.payload.branch}`,
                 icon_url: `https://github.com/${this.body.payload.committer_name}.png`
             },
-            description: `[\`${this.body.payload.vcs_revision.slice(0,7)}\`](${this.body.payload.compare}) : ${this.body.payload.subject} - ${this.body.payload.committer_name}\n\`Outcome\`: ${this.body.payload.outcome}`
+            description: `[\`${this.body.payload.vcs_revision.slice(0,7)}\`](${this.body.payload.compare}) : ${subject} - ${this.body.payload.committer_name}\n\`Outcome\`: ${this.body.payload.outcome}`
         });
     }
 }

--- a/providers/circleci.js
+++ b/providers/circleci.js
@@ -11,12 +11,13 @@ class CircleCi extends BaseProvider {
     async parseData(req) {
         this.payload.setEmbedColor(0x000000);
         this.payload.addEmbed({
-            title: "Build #" + this.body.payload.build_num,
+            title: `Build #${this.body.payload.build_num}`,
             url: this.body.payload.build_url,
             author: {
-                name: this.body.payload.reponame
+                name: `${this.body.payload.reponame}:${this.body.payload.branch}`,
+                icon_url: `https://github.com/${this.body.payload.committer_name}.png`
             },
-            description: "**Outcome**: " + this.body.payload.outcome
+            description: `[\`${this.body.payload.vcs_revision.slice(0,7)}\`](${this.body.payload.compare}) : ${this.body.payload.subject} - ${this.body.payload.committer_name}\n\`Outcome\`: ${this.body.payload.outcome}`
         });
     }
 }

--- a/providers/circleci.js
+++ b/providers/circleci.js
@@ -9,7 +9,7 @@ class CircleCi extends BaseProvider {
     }
 
     async parseData(req) {
-        this.payload.setEmbedColor('#343433');
+        this.payload.setEmbedColor(0x343433);
         this.payload.addEmbed({
             title: `Build #${this.body.payload.build_num}`,
             url: this.body.payload.build_url,

--- a/providers/circleci.js
+++ b/providers/circleci.js
@@ -9,7 +9,7 @@ class CircleCi extends BaseProvider {
     }
 
     async parseData(req) {
-        this.payload.setEmbedColor(0x000000);
+        this.payload.setEmbedColor('#343433');
         this.payload.addEmbed({
             title: `Build #${this.body.payload.build_num}`,
             url: this.body.payload.build_url,


### PR DESCRIPTION
Currently the `outcome` part of the description is also in an inline code block as IMO it looks better but if I need to change that back to just bold text LMK. Both options shown here:

![](https://favna.s-ul.eu/1Snx0Dml.png)

Edit: The styling for the commit hash is inspired by GitHub's own webhooks as seen here:

![](https://favna.s-ul.eu/6AlEtOZj.png)

Edit 2:

Look after 98c09c5:

![](https://favna.s-ul.eu/u40Mo16J.png)

---

The build 8  in the first screenshot had multiple commits in the single build and I was seeing if I could get all commit hashes but that is not part of the `this.body.payload`. Maybe that's something on CircleCI's end but if it's something you can fetch still that would be a great addition and then I'll ensure it gets put towards the webhook properly. That is to say, all I need is the data to be available in `this.body.payload`.

Build 8 in question is here: https://circleci.com/gh/Favna/circlci/8

Note: repo used for testing the circleci (as linked on the build page) is a private one.