### PR TITLE
Support for Gitlab approved merge request

### DIFF
--- a/providers/gitlab.js
+++ b/providers/gitlab.js
@@ -153,7 +153,8 @@ class GitLab extends BaseProvider {
             close: "Closed",
             reopen: "Reopened",
             update: "Updated",
-            merge: "Merged"
+            merge: "Merged",
+            approved: "Approved"
         };
 
         this.payload.addEmbed({


### PR DESCRIPTION
> An unknown event has been emitted.
> This most likely means the developers have not gotten to styling this event.
> The event in question was merge_request/approved

I did not test this.