### PR TITLE
Support for Gitlab (un)approved merge request

### DIFF
--- a/src/providers/GitLab.ts
+++ b/src/providers/GitLab.ts
@@ -130,7 +130,9 @@ class GitLab extends BaseProvider {
             close: 'Closed',
             reopen: 'Reopened',
             update: 'Updated',
-            merge: 'Merged'
+            merge: 'Merged',
+            approved: "Approved",
+            unapproved: "Unapproved"
         }
         const field = new EmbedField()
         field.name = this.body.object_attributes.title


### PR DESCRIPTION
This pull request intend to fix the following errors:
> An unknown event has been emitted.
This most likely means the developers have not gotten to styling this event.
The event in question was merge_request/approved

> An unknown event has been emitted.
This most likely means the developers have not gotten to styling this event.
The event in question was merge_request/unapproved

Again, I did not test this.

---
Old pull request: #86 
cc @Jawnnypoo 