### PR TITLE
Fix for unity payload change.

### DIFF
--- a/src/providers/Unity.ts
+++ b/src/providers/Unity.ts
@@ -19,8 +19,10 @@ class Unity extends BaseProvider {
         const projectName = this.body.projectName
         const projectVersion = this.body.buildNumber
         let share = null
-        if (this.body.links != null) {
-            share = this.body.links.share_url
+        try {
+            share = this.body.links.artifacts[0].files.href
+        } catch (err) {
+            // Artifact not present
         }
         const type = this.body.buildStatus
         let content = 'No download available.'


### PR DESCRIPTION
Should fix the issue reported in #89. I don't see any documentation for this on the unity site though, so I'm opening this PR for you guys to test it out.

Could be related to this? https://feedback.unity3d.com/suggestions/support-discord-webhooks-as-a-cloud-build-notification