### PR TITLE
#96: Adds support for github anonymous users

### DIFF
--- a/src/provider/Bitbucket.ts
+++ b/src/provider/Bitbucket.ts
@@ -304,7 +304,7 @@ class BitBucket extends BaseProvider {
     private extractAuthor(): EmbedAuthor {
         const author = new EmbedAuthor()
         author.name = this.body.actor.display_name
-        if (author.name === 'Anonymous' && this.body.actor.links === undefined) {
+        if (this.body.actor.links === undefined) {
             author.iconUrl = 'http://i0.wp.com/avatar-cdn.atlassian.com/default/96.png'
             author.url = ''
         } else {

--- a/src/provider/Bitbucket.ts
+++ b/src/provider/Bitbucket.ts
@@ -304,7 +304,7 @@ class BitBucket extends BaseProvider {
     private extractAuthor(): EmbedAuthor {
         const author = new EmbedAuthor()
         author.name = this.body.actor.display_name
-        if (author.name === 'Anonymous') {
+        if (author.name === 'Anonymous' && this.body.actor.links === undefined) {
             author.iconUrl = 'http://i0.wp.com/avatar-cdn.atlassian.com/default/96.png'
             author.url = ''
         } else {

--- a/src/provider/Bitbucket.ts
+++ b/src/provider/Bitbucket.ts
@@ -304,8 +304,13 @@ class BitBucket extends BaseProvider {
     private extractAuthor(): EmbedAuthor {
         const author = new EmbedAuthor()
         author.name = this.body.actor.display_name
-        author.iconUrl = this.body.actor.links.avatar.href
-        author.url = this.baseLink + this.body.actor.username
+        if (author.name === 'Anonymous') {
+            author.iconUrl = 'http://i0.wp.com/avatar-cdn.atlassian.com/default/96.png'
+            author.url = ''
+        } else {
+            author.iconUrl = this.body.actor.links.avatar.href
+            author.url = this.baseLink + this.body.actor.username
+        }
         return author
     }
 

--- a/test/bitbucket-anonymous.json
+++ b/test/bitbucket-anonymous.json
@@ -1,0 +1,230 @@
+{    
+  "actor": {
+    "type": "user",
+    "display_name": "Anonymous"
+  },
+  "repository": {
+    "type": "repository",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/api/2.0/repositories/bitbucket/bitbucket"
+      },
+      "html": {
+        "href": "https://api.bitbucket.org/bitbucket/bitbucket"
+      },
+      "avatar": {
+        "href": "https://api-staging-assetroot.s3.amazonaws.com/c/photos/2014/Aug/01/bitbucket-logo-2629490769-3_avatar.png"
+      }
+    },
+    "uuid": "{673a6070-3421-46c9-9d48-90745f7bfe8e}",
+    "project": {
+      "type": "project",
+      "project": "Untitled project",
+      "uuid": "{3b7898dc-6891-4225-ae60-24613bb83080}",
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/account/user/teamawesome/projects/proj"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/user/teamawesome/projects/proj/avatar/32"
+        }
+      },
+      "key": "proj"
+    },
+    "full_name": "team_name/repo_name",
+    "name": "repo_name",
+    "website": "https://mywebsite.com/",
+    "owner": {
+      "type": "user",
+      "username": "emmap1",
+      "display_name": "Emma",
+      "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+        },
+        "html": {
+          "href": "https://api.bitbucket.org/emmap1"
+        },
+        "avatar": {
+          "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+        }
+      }
+    },
+    "scm": "git",
+    "is_private": true
+  },
+  "push": {
+    "changes": [
+      {
+        "new": {
+          "type": "branch",
+          "name": "name-of-branch",
+          "target": {
+            "type": "commit",
+            "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
+            "author": {
+              "type": "user",
+              "username": "emmap1",
+              "display_name": "Emma",
+              "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+              "links": {
+                "self": {
+                  "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+                },
+                "html": {
+                  "href": "https://api.bitbucket.org/emmap1"
+                },
+                "avatar": {
+                  "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+                }
+              }
+            },
+            "message": "new commit message\n",
+            "date": "2015-06-09T03:34:49+00:00",
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "1e65c05c1d5171631d92438a13901ca7dae9618c",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/8cbbd65829c7ad834a97841e0defc965718036a0"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/user_name/repo_name/commits/8cbbd65829c7ad834a97841e0defc965718036a0"
+                  }
+                }
+              }
+            ],
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/c4b2b7914156a878aa7c9da452a09fb50c2091f2"
+              },
+              "html": {
+                "href": "https://bitbucket.org/user_name/repo_name/commits/c4b2b7914156a878aa7c9da452a09fb50c2091f2"
+              }
+            }
+          },
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/refs/branches/master"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commits/master"
+            },
+            "html": {
+              "href": "https://bitbucket.org/user_name/repo_name/branch/master"
+            }
+          }
+        },
+        "old": {
+          "type": "branch",
+          "name": "name-of-branch",
+          "target": {
+            "type": "commit",
+            "hash": "1e65c05c1d5171631d92438a13901ca7dae9618c",
+            "author": {
+              "type": "user",
+              "username": "emmap1",
+              "display_name": "Emma",
+              "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+              "links": {
+                "self": {
+                  "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+                },
+                "html": {
+                  "href": "https://api.bitbucket.org/emmap1"
+                },
+                "avatar": {
+                  "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+                }
+              }
+            },
+            "message": "old commit message\n",
+            "date": "2015-06-08T21:34:56+00:00",
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "e0d0c2041e09746be5ce4b55067d5a8e3098c843",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/9c4a3452da3bc4f37af5a6bb9c784246f44406f7"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/user_name/repo_name/commits/9c4a3452da3bc4f37af5a6bb9c784246f44406f7"
+                  }
+                }
+              }
+            ],
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+              },
+              "html": {
+                "href": "https://bitbucket.org/user_name/repo_name/commits/b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+              }
+            }
+          },
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/refs/branches/master"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commits/master"
+            },
+            "html": {
+              "href": "https://bitbucket.org/user_name/repo_name/branch/master"
+            }
+          }
+        },
+        "links": {
+          "html": {
+            "href": "https://bitbucket.org/user_name/repo_name/branches/compare/c4b2b7914156a878aa7c9da452a09fb50c2091f2..b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+          },
+          "diff": {
+            "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/diff/c4b2b7914156a878aa7c9da452a09fb50c2091f2..b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+          },
+          "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commits?include=c4b2b7914156a878aa7c9da452a09fb50c2091f2&exclude=b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+          }
+        },
+        "created": false,
+        "forced": false,
+        "closed": false,
+        "commits": [
+          {
+            "hash": "03f4a7270240708834de475bcf21532d6134777e",
+            "type": "commit",
+            "message": "commit message\n",
+            "author": {
+              "type": "user",
+              "username": "emmap1",
+              "display_name": "Emma",
+              "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+              "links": {
+                "self": {
+                  "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+                },
+                "html": {
+                  "href": "https://api.bitbucket.org/emmap1"
+                },
+                "avatar": {
+                  "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+                }
+              }
+            },
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/user/repo/commit/03f4a7270240708834de475bcf21532d6134777e"
+              },
+              "html": {
+                "href": "https://bitbucket.org/user/repo/commits/03f4a7270240708834de475bcf21532d6134777e"
+              }
+            }
+          }
+        ],
+        "truncated": false
+      }
+    ]
+  }
+}

--- a/test/bitbucketTests.ts
+++ b/test/bitbucketTests.ts
@@ -7,7 +7,16 @@ describe('/POST bitbucket', () => {
         const headers = {
             'x-event-key': 'repo:push'
         }
-        const res = Tester.test(new BitBucket(), 'bitbucket.json', headers)
+        const res = await Tester.test(new BitBucket(), 'bitbucket.json', headers)
+        expect(res).to.not.be.an('error')
+        expect(res).to.not.be.a('DiscordPayload')
+    })
+
+    it('repo:push should work with anonymous users', async () => {
+        const headers = {
+            'x-event-key': 'repo:push'
+        }
+        const res = await Tester.test(new BitBucket(), 'bitbucket-anonymous.json', headers)
         expect(res).to.not.be.an('error')
         expect(res).to.not.be.a('DiscordPayload')
     })


### PR DESCRIPTION
- Not sure the best way to deal with the avatar. I found a link to the bitbucket anonymous one which I just hardcoded in. It works but that image may disappear.
- Added a new test for the issue also.
- Original bitbucket test is missing the `await` on the promise also, but was passing when I added it.

I'm not sure of the chances of it happening but if someone uses the username `Anonymous` on github this might lessen skyhook's functionality for them. If you want extra confidence you could also do a check for `this.body.actor.links` being undefined.