### PR TITLE
leverage docker multistage to break up build and run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:10.15.0 as buildenv
+FROM node:10.15 as buildenv
 
 WORKDIR /app
 COPY . .
 RUN npm install && npm run build
 
-FROM node:10.15.0
+FROM node:10.15
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM node:8.9 as buildenv
+
+RUN apk update && apk upgrade
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+
 FROM node:8.9
 
 RUN mkdir -p /usr/src/app
@@ -9,6 +16,10 @@ COPY package.json /usr/src/app/
 COPY package-lock.json /usr/src/app/
 RUN npm install && npm cache clean --force
 COPY . /usr/src/app
+
+RUN mkdir dist
+COPY --from=buildenv /app/dist .
+RUN ls
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY --from=buildenv /app/dist /usr/src/app/dist
 
 EXPOSE 8080
 
-CMD [ "npm", "start" ]
+CMD [ "npm", "run", "dockerstart" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN npm install && npm cache clean --force
 COPY . /usr/src/app
 
 RUN mkdir dist
-COPY --from=buildenv /app/dist .
-RUN ls
+COPY --from=buildenv /app/dist /usr/src/app/dist
+RUN ls dist
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:8.9 as buildenv
 
-RUN apk update && apk upgrade
 WORKDIR /app
 COPY . .
 RUN npm install && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY . /usr/src/app
 
 RUN mkdir dist
 COPY --from=buildenv /app/dist /usr/src/app/dist
-RUN ls dist
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:11.6.0 as buildenv
+FROM node:10.15.0 as buildenv
 
 WORKDIR /app
 COPY . .
 RUN npm install && npm run build
 
-FROM node:11.6.0
+FROM node:10.15.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:8.9 as buildenv
+FROM node:11.6.0 as buildenv
 
 WORKDIR /app
 COPY . .
 RUN npm install && npm run build
 
-FROM node:8.9
+FROM node:11.6.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "clean": "rimraf dist",
     "tsc": "tsc",
     "build": "npm run clean && npm run tsc",
-    "start": "node dist/index.js",
+    "dockerstart": "node dist/index.js",
+    "start": "npm run build && node dist/index.js",
     "test": "mocha -r ts-node/register test/*.ts",
     "lint": "tslint --project .",
     "visualTest": "npm run build && node dist/test.js"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "clean": "rimraf dist",
     "tsc": "tsc",
     "build": "npm run clean && npm run tsc",
-    "start": "npm run build && node dist/index.js",
+    "start": "node dist/index.js",
     "test": "mocha -r ts-node/register test/*.ts",
     "lint": "tslint --project .",
     "visualTest": "npm run build && node dist/test.js"


### PR DESCRIPTION
I've extracted the bundle step to a buildenv in docker--this lowers the ram overhead on spinup of the container and ensures that some of the wonkiness of npm doesn't get in the way of a deploy.