### PR TITLE
Extend Docker Hub information

### DIFF
--- a/src/provider/DockerHub.ts
+++ b/src/provider/DockerHub.ts
@@ -12,7 +12,8 @@ class DockerHub extends BaseProvider {
     public async parseData() {
         this.setEmbedColor(0xFFFFFF)
         const embed = new Embed()
-        embed.title = 'New push for tag: ' + this.body.push_data.tag
+        embed.title = this.body.repository.repo_name
+        embed.description = 'New push for tag: ' + this.body.push_data.tag
         embed.url = this.body.repository.repo_url
         this.addEmbed(embed)
     }


### PR DESCRIPTION
Sets the title to be the repository name (username/project), and description to be the new tag information instead of the title