### PR TITLE
Adding more information on the AppVeyor responses

### DIFF
--- a/src/provider/Appveyor.ts
+++ b/src/provider/Appveyor.ts
@@ -19,9 +19,9 @@ class AppVeyor extends BaseProvider {
         embed.description = '**Status**: ' + this.body.eventData.status
         const author = new EmbedAuthor()
         author.name = this.body.eventData.commitAuthor
-        if (this.body.eventData.repositoryProvider == "gitHub")
+        if (this.body.eventData.repositoryProvider == 'gitHub')
         {
-            author.url = "https://github.com/" + this.body.eventData.repositoryName + "/commit/" + this.body.eventData.commitId
+            author.url = 'https://github.com/' + this.body.eventData.repositoryName + '/commit/' + this.body.eventData.commitId
         }
         embed.author = author
         this.addEmbed(embed)

--- a/src/provider/Appveyor.ts
+++ b/src/provider/Appveyor.ts
@@ -11,7 +11,7 @@ class AppVeyor extends BaseProvider {
     }
 
     public async parseData() {
-        this.setEmbedColor(0xFFFFFF)
+        this.setEmbedColor(0x00B3E0)
         const embed = new Embed()
         embed.description = '**Status**: ' + this.body.eventData.status
         embed.title = 'Build #' + this.body.eventData.buildNumber

--- a/src/provider/Appveyor.ts
+++ b/src/provider/Appveyor.ts
@@ -19,6 +19,10 @@ class AppVeyor extends BaseProvider {
         embed.description = '**Status**: ' + this.body.eventData.status
         const author = new EmbedAuthor()
         author.name = this.body.eventData.commitAuthor
+        if (this.body.eventData.repositoryProvider == "gitHub")
+        {
+            author.url = "https://github.com/" + this.body.eventData.repositoryName + "/commit/" + this.body.eventData.commitId
+        }
         embed.author = author
         this.addEmbed(embed)
     }

--- a/src/provider/Appveyor.ts
+++ b/src/provider/Appveyor.ts
@@ -1,4 +1,5 @@
 import { Embed } from '../model/Embed'
+import { EmbedAuthor } from '../model/EmbedAuthor'
 import { BaseProvider } from '../provider/BaseProvider'
 
 /**
@@ -13,9 +14,12 @@ class AppVeyor extends BaseProvider {
     public async parseData() {
         this.setEmbedColor(0x00B3E0)
         const embed = new Embed()
-        embed.description = '**Status**: ' + this.body.eventData.status
         embed.title = 'Build #' + this.body.eventData.buildNumber
         embed.url = this.body.eventData.buildUrl
+        embed.description = '**Status**: ' + this.body.eventData.status
+        const author = new EmbedAuthor()
+        author.name = this.body.eventData.commitAuthor
+        embed.author = author
         this.addEmbed(embed)
     }
 }

--- a/src/provider/Appveyor.ts
+++ b/src/provider/Appveyor.ts
@@ -16,7 +16,7 @@ class AppVeyor extends BaseProvider {
         const embed = new Embed()
         embed.title = 'Build ' + this.body.eventData.buildVersion
         embed.url = this.body.eventData.buildUrl
-        embed.description = '**Status**: ' + this.body.eventData.status
+        embed.description = this.body.eventData.commitMessage + '\n\n' + '**Status**: ' + this.body.eventData.status
         const author = new EmbedAuthor()
         author.name = this.body.eventData.commitAuthor
         if (this.body.eventData.repositoryProvider == 'gitHub')

--- a/src/provider/Appveyor.ts
+++ b/src/provider/Appveyor.ts
@@ -14,7 +14,7 @@ class AppVeyor extends BaseProvider {
     public async parseData() {
         this.setEmbedColor(0x00B3E0)
         const embed = new Embed()
-        embed.title = 'Build #' + this.body.eventData.buildNumber
+        embed.title = 'Build ' + this.body.eventData.buildVersion
         embed.url = this.body.eventData.buildUrl
         embed.description = '**Status**: ' + this.body.eventData.status
         const author = new EmbedAuthor()

--- a/src/provider/Appveyor.ts
+++ b/src/provider/Appveyor.ts
@@ -24,6 +24,13 @@ class AppVeyor extends BaseProvider {
             author.url = 'https://github.com/' + this.body.eventData.repositoryName + '/commit/' + this.body.eventData.commitId
         }
         embed.author = author
+        if (this.body.eventData.jobs[0].artifacts.length != 0)
+        {
+            embed.description += '\n**Artifacts**:'
+            for (let i=0; i < this.body.eventData.jobs[0].artifacts.length; i++){
+                embed.description += '\n- [' + this.body.eventData.jobs[0].artifacts[i].fileName + '](' + this.body.eventData.jobs[0].artifacts[i].permalink + ')'
+            }
+        }
         this.addEmbed(embed)
     }
 }


### PR DESCRIPTION
Closes #117 
![image](https://user-images.githubusercontent.com/11861253/51454712-d9b42200-1d24-11e9-948e-4f65e4574d3c.png)
If there are no artifacts, the section is not shown:
![image](https://user-images.githubusercontent.com/11861253/51454797-5a731e00-1d25-11e9-913a-7bbf9e3ef23b.png)
For now, the artifacts are only for the first build. I'm not checking `this.body.eventData.jobs` because there is always going to be a build, otherwise AppVeyor does not works and the WebHook does not gets triggered.

I used [ARC](https://install.advancedrestclient.com/install) to test the changes.