### PR TITLE
fix(jira): Handle comment webhook description correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ jspm_packages
 
 # Custom
 dist
+.idea
+

--- a/src/provider/Jira.ts
+++ b/src/provider/Jira.ts
@@ -5,10 +5,9 @@ import { BaseProvider } from '../provider/BaseProvider'
  * https://developer.atlassian.com/server/jira/platform/webhooks/
  */
 class Jira extends BaseProvider {
-
-    private static capitalize(str: string) {
-        const tmp = str.toLowerCase()
-        return tmp.charAt(0).toUpperCase() + tmp.slice(1)
+    constructor() {
+        super()
+        this.setEmbedColor(0x1e45a8)
     }
 
     public getName() {
@@ -20,36 +19,35 @@ class Jira extends BaseProvider {
     }
 
     public async parseData() {
-        this.setEmbedColor(0x1e45a8)
-
-        // We don't support anything else at this time.
-        if (!this.body.webhookEvent.startsWith('jira:issue_')) {
+        let isIssue: boolean
+        if (this.body.webhookEvent.startsWith('jira:issue_')) {
+            isIssue = true
+        } else if (this.body.webhookEvent.startsWith('comment_')) {
+            isIssue = false
+        } else {
             return
         }
 
         // extract variable from Jira
         const issue = this.body.issue
-        const comment = this.body.comment
+        if (issue.fields.assignee == null) {
+            issue.fields.assignee = {displayName: 'nobody'}
+        }
         const user = this.body.user
         const action = this.body.webhookEvent.split('_')[1]
         const matches = issue.self.match(/^(https?:\/\/[^\/?#]+)(?:[\/?#]|$)/i)
         const domain = matches && matches[1]
 
-        if (issue.fields.assignee == null) {
-            issue.fields.assignee = {displayName: 'nobody'}
-        }
-
-        // embed builder
-        const embed = new Embed()
+        // create the embed
+        let embed = new Embed()
         embed.title = `${issue.key} - ${issue.fields.summary}`
-
-        if (comment != null) {
-            embed.description = `${comment.updateAuthor.displayName} commented: ${comment.body}`
-        } else {
-            embed.description = `${user.displayName} ${action} the issue ${embed.title} (${issue.fields.assignee.displayName})`
-        }
-
         embed.url = `${domain}/browse/${issue.key}`
+        if (isIssue) {
+            embed.description = `${user.displayName} ${action} issue: ${embed.title} (${issue.fields.assignee.displayName})`
+        } else {
+            const comment = this.body.comment
+            embed.description = `${comment.updateAuthor.displayName} ${action} comment: ${comment.body}`
+        }
         this.addEmbed(embed)
     }
 }

--- a/test/jira-comment.json
+++ b/test/jira-comment.json
@@ -75,5 +75,5 @@
         "created":"2011-06-07T10:31:26.805-0500",
         "updated":"2011-06-07T10:31:26.805-0500"
     },  
-    "webhookEvent": "jira:issue_updated"
+    "webhookEvent": "comment_created"
 }


### PR DESCRIPTION
Fixes #119 - we weren't correctly detecting the comment webhook type, Jira unfortunately provides little documentation on the expected JSON object, so were silently dropping those events. This PR restores the expected behaviour.