### PR TITLE
fix: discord enforcing application/json-content type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,10 @@ app.post('/api/webhooks/:webhookID/:webhookSecret/:from', async (req, res) => {
         axios({
             data: jsonString,
             method: 'post',
-            url: discordEndpoint
+            url: discordEndpoint,
+            headers: {
+                'Content-Type': 'application/json'
+            }
         }).then(() => {
             res.sendStatus(200)
         }).catch((err: any) => {


### PR DESCRIPTION
It seems like Discord has changed its webhooks to enforce Content-Types:
![image](https://user-images.githubusercontent.com/6546697/69557367-c60dc380-0fa6-11ea-8f3b-8e63fe4c9709.png)
(Taken from the "Discord API"-Discord)

Thereby requests without `application/json`, `multipart/form-data` or `application/x-www-form-urlencoded` seem to be blocked.

This PR shoud fix https://github.com/Commit451/skyhook/issues/135. I have tested it locally.