### PR TITLE
WIP Bitbucket Provider

### DIFF
--- a/src/provider/Bitbucket.ts
+++ b/src/provider/Bitbucket.ts
@@ -317,6 +317,15 @@ class BitBucket extends BaseProvider {
         this.addEmbed(this.embed)
     }
 
+    /**
+     * Bitbucket Server Test Connection
+     */
+    public async diagnosticsPing() {
+        this.embed.title = 'Test Connection'
+        this.embed.description = `Test: ${this.body.test}`
+        this.addEmbed(this.embed)
+    }
+
     private extractAuthor(): EmbedAuthor {
         const author = new EmbedAuthor()
         author.name = this.body.actor.display_name

--- a/src/provider/Bitbucket.ts
+++ b/src/provider/Bitbucket.ts
@@ -1,7 +1,7 @@
 import { Embed } from '../model/Embed'
 import { EmbedAuthor } from '../model/EmbedAuthor'
 import { EmbedField } from '../model/EmbedField'
-import { BaseProvider } from '../provider/BaseProvider'
+import { BaseProvider } from './BaseProvider'
 import { MarkdownUtil } from '../util/MarkdownUtil'
 
 /**
@@ -27,7 +27,9 @@ class BitBucket extends BaseProvider {
         return strArray.join(' ')
     }
 
-    private baseLink: string = 'https://bitbucket.org/'
+    // Check to see if there a env variable named SERVER. If there isn't, use the standard
+    // Bitbucket Cloud, if there is then we are using Bitbucket Server.
+    private baseLink: string = this.extractBitbucketUrl()
     private embed: Embed
 
     constructor() {
@@ -341,6 +343,14 @@ class BitBucket extends BaseProvider {
 
     private extractIssueUrl(): string {
         return this.baseLink + this.body.repository.full_name + '/issues/' + this.body.issue.id
+    }
+
+    private extractBitbucketUrl(): string {
+        if (process.env.SERVER === null) {
+            return 'https://bitbucket.org/'
+        } else {
+            return process.env.SERVER
+        }
     }
 }
 


### PR DESCRIPTION
Up to date as of Bitbucker Server v7.1
## New Environment Variable
In order to set this up with Bitbucket Server, I added a new method, `extractBitbucketUrl` which looks for the `process.env.SERVER` variable. This variable should hold your Bitbucket Server URL. If you don't specify this, it will auto use the Bitbucket Cloud one.

## Diagnostics Ping
![image](https://user-images.githubusercontent.com/11448029/79056508-4e72c500-7c25-11ea-8182-2151a1065a96.png)

