### PR TITLE
VSTS fix for markdown greater than 256 chars

### DIFF
--- a/src/provider/VSTS.ts
+++ b/src/provider/VSTS.ts
@@ -153,12 +153,8 @@ class VSTS extends BaseProvider {
     private addMinimalMessage() {
         this.embed.title = this.body.message.markdown
 		
-		console.log(this.embed.title.length);
-		
 		if (this.embed.title.length > 256)
 			this.embed.title = this.body.resource.title ?? this.body.message.markdown.substring(0, 256);
-		
-		console.log(this.embed.title);
 		
         this.addEmbed(this.embed)
     }

--- a/src/provider/VSTS.ts
+++ b/src/provider/VSTS.ts
@@ -152,6 +152,14 @@ class VSTS extends BaseProvider {
     // Because carpal tunnel...
     private addMinimalMessage() {
         this.embed.title = this.body.message.markdown
+		
+		console.log(this.embed.title.length);
+		
+		if (this.embed.title.length > 256)
+			this.embed.title = this.body.resource.title ?? this.body.message.markdown.substring(0, 256);
+		
+		console.log(this.embed.title);
+		
         this.addEmbed(this.embed)
     }
 


### PR DESCRIPTION
Azure Devops (VSTS) may send the markdown field with more than 256 chars exceeding the Discord limit for the title field.
So when this happens, im chaging to use the Resource Title or, if its unnavailable, the markdown field truncated to 256 chars.