### PR TITLE
New DockerHub Embed!

### DIFF
--- a/src/provider/DockerHub.ts
+++ b/src/provider/DockerHub.ts
@@ -11,10 +11,10 @@ class DockerHub extends BaseProvider {
     }
 
     public async parseData(): Promise<void> {
-        this.setEmbedColor(0xFFFFFF)
+        this.setEmbedColor(0x0db7ed)
         const embed = new Embed()
-        embed.title = this.body.repository.repo_name
-        embed.description = 'New push for tag: ' + this.body.push_data.tag
+        embed.title = '🐳 Repository: ' + this.body.repository.repo_name
+        embed.description = `${this.body.push_data.pusher} pushed for tag: **${this.body.push_data.tag}**`
         embed.url = this.body.repository.repo_url
         this.addEmbed(embed)
     }


### PR DESCRIPTION
Yo! I think the old Docker Hub embed is half...dead? So I decided to improve it.

Before: 
![image](https://user-images.githubusercontent.com/39680458/99925306-6a425b80-2d1c-11eb-95c9-7ca04597799d.png)

After:
![image](https://user-images.githubusercontent.com/39680458/99925320-79290e00-2d1c-11eb-840f-d9cce83d3858.png)
