### PR TITLE
Support paths in Jira browse URLs

### DIFF
--- a/src/provider/Basecamp.ts
+++ b/src/provider/Basecamp.ts
@@ -1,11 +1,11 @@
-import {Embed} from '../model/Embed'
-import {BaseProvider} from '../provider/BaseProvider'
-import * as fs from 'fs'
-import {EmbedAuthor} from '../model/EmbedAuthor'
+import { Embed } from '../model/Embed'
+import { BaseProvider } from '../provider/BaseProvider'
+import { EmbedAuthor} from '../model/EmbedAuthor'
 
 import TurndownService from 'turndown'
 
 class Basecamp extends BaseProvider {
+
     private turndown: TurndownService
     private colorCreated = 0x00ff00
     private colorDeleted = 0xff0000
@@ -212,4 +212,4 @@ class Basecamp extends BaseProvider {
     }
 }
 
-export {Basecamp}
+export { Basecamp }

--- a/src/provider/Jira.ts
+++ b/src/provider/Jira.ts
@@ -40,13 +40,11 @@ class Jira extends BaseProvider {
         }
         const user = this.body.user || { displayName: 'Anonymous' }
         const action = this.body.webhookEvent.split('_')[1]
-        const matches = issue.self.match(/^(https?:\/\/[^/?#]+)(?:[/?#]|$)/i)
-        const domain = matches && matches[1]
 
         // create the embed
         const embed = new Embed()
         embed.title = `${issue.key} - ${issue.fields.summary}`
-        embed.url = `${domain}/browse/${issue.key}`
+        embed.url = this.createBrowseUrl(issue)
         if (isIssue) {
             embed.description = `${user.displayName} ${action} issue: ${embed.title} (${issue.fields.assignee.displayName})`
         } else {
@@ -54,6 +52,13 @@ class Jira extends BaseProvider {
             embed.description = `${comment.updateAuthor.displayName} ${action} comment: ${comment.body}`
         }
         this.addEmbed(embed)
+    }
+
+    private createBrowseUrl(issue): string {
+        const url: URL = new URL(issue.self)
+        const path: string|RegExpMatchArray = url.pathname.match(/.+?(?=\/rest\/api)/) ?? ''
+        url.pathname = `${path}/browse/${issue.key}`
+        return url.toString()
     }
 }
 

--- a/test/Tester.ts
+++ b/test/Tester.ts
@@ -8,6 +8,7 @@ import { DiscordPayload } from '../src/model/DiscordPayload'
  * Helps with testing things
  */
 class Tester {
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public static async test(provider: BaseProvider, jsonFileName: string = null, headers: any = null, query: any = null): Promise<DiscordPayload> {
         LoggerUtil.init()
@@ -31,8 +32,7 @@ class Tester {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public static readTestFile(provider: BaseProvider, fileName: string): any {
+    public static readTestFile(provider: BaseProvider, fileName: string): string {
         return fs.readFileSync(`./test/${provider.getPath().toLowerCase()}/${fileName}`, 'utf-8')
     }
 }

--- a/test/Tester.ts
+++ b/test/Tester.ts
@@ -11,19 +11,29 @@ class Tester {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public static async test(provider: BaseProvider, jsonFileName: string = null, headers: any = null, query: any = null): Promise<DiscordPayload> {
         LoggerUtil.init()
-        let jsonObject = null
+        let requestBody = null
         if (jsonFileName != null) {
-            const json = fs.readFileSync(`./test/${provider.getPath().toLowerCase()}/${jsonFileName}`, 'utf-8')
-            jsonObject = JSON.parse(json)
+            requestBody = JSON.parse(Tester.readTestFile(provider, jsonFileName))
         }
+        return Tester.testWithBody(provider, requestBody, headers, query)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public static async testWithBody(provider: BaseProvider, body: Record<string, any> = null, headers: any = null, query: any = null): Promise<DiscordPayload> {
+        LoggerUtil.init()
         try {
-            const res = await provider.parse(jsonObject, headers, query)
+            const res = await provider.parse(body, headers, query)
             console.log(inspect(res, false, null, true))
             return Promise.resolve(res)
         } catch (err) {
             console.error(err)
             return Promise.reject(err)
         }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public static readTestFile(provider: BaseProvider, fileName: string): any {
+        return fs.readFileSync(`./test/${provider.getPath().toLowerCase()}/${fileName}`, 'utf-8')
     }
 }
 

--- a/test/jira/jiraTests.ts
+++ b/test/jira/jiraTests.ts
@@ -19,5 +19,15 @@ describe('/POST jira', () => {
         expect(res).to.be.a('null')
     })
 
+    it('browse_url', async () => {
+        const provider: Jira = new Jira()
+        const requestBody = JSON.parse(Tester.readTestFile(provider, 'jira-issue.json'))
 
+        let res = await Tester.testWithBody(new Jira(), requestBody, null)
+        expect(res.embeds[0].url).to.be.equal('https://jira.atlassian.com/browse/JRA-20002')
+
+        requestBody.issue.self = 'https://jira.atlassian.com/our/path/rest/api/2/issue/99291'
+        res = await Tester.testWithBody(new Jira(), requestBody, null)
+        expect(res.embeds[0].url).to.be.equal('https://jira.atlassian.com/our/path/browse/JRA-20002')
+    })
 })


### PR DESCRIPTION
When a (self-hosted) Jira URL contains a path the "browse" URL to go to the ticket will break. It ignores the path as the regular expression currently in place does not take this possibility into consideration.

**URL**
`https://www.example.com/our/path/rest/api/2/issue/99291`

**Expected Result**
`https://www.example.com/our/path/browse/JRA-20002`

**Actual Result**
`https://www.example.com/browse/JRA-20002`