### PR TITLE
New Provider: Prometheus

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { Unity } from './provider/Unity'
 import { UptimeRobot } from './provider/UptimeRobot'
 import { VSTS } from './provider/VSTS'
 import { Type } from './util/TSUtility'
+import { Prometheus } from './provider/Prometheus'
 
 dotenv.config()
 
@@ -58,6 +59,7 @@ const providers: Type<BaseProvider>[] = [
     NewRelic,
     Patreon,
     Pingdom,
+    Prometheus,
     Rollbar,
     Travis,
     Trello,

--- a/src/provider/Prometheus.ts
+++ b/src/provider/Prometheus.ts
@@ -1,0 +1,81 @@
+import { Embed, EmbedField, EmbedAuthor } from '../model/DiscordApi'
+import { TypeParseProvder } from './BaseProvider'
+
+export class Prometheus extends TypeParseProvder {
+    private embed: Embed
+    constructor() {
+        super()
+        this.setEmbedColor(0x205081)
+        this.embed = {}
+    }
+
+    public preParse(): void {
+        this.headers = ['x-skyhook-event']
+        // Prometheus does not have a type, so we set our own.
+        this.headers['x-skyhook-event'] = 'fire'
+    }
+
+    public getName(): string {
+        return 'Prometheus'
+    }
+
+    public getType(): string | null {
+        // Prometheus does not have a type, so we set our own.
+        return this.headers['x-skyhook-event']
+    }
+
+    public knownTypes(): string[] {
+        return ['fire']
+    }
+
+    /**
+     * There is no event type for this provider. Creating a single
+     * method to handle all events.
+     */
+    public async fire(): Promise<void> {
+        // Set Embed Author
+        this.embed.author = this.extractAuthor()
+
+        // Set Embed Title
+        this.embed.title = this.body.groupLabels?.alertname
+
+        this.embed.url = this.body.externalURL
+
+        // Set Embed Fields
+        this.embed.fields = this.extractAlertDescriptions()
+
+        this.addEmbed(this.embed)
+    }
+
+    private extractAuthor(): EmbedAuthor {
+        return {
+            name: 'Prometheus Alert',
+            icon_url: 'https://avatars.githubusercontent.com/u/3380462?s=200&v=4',
+        }
+    }
+
+    private extractAlertDescriptions(): EmbedField[] {
+        const fieldArray: EmbedField[] = []
+
+        // As per https://discord.com/developers/docs/resources/channel#embed-limits-limits
+        // Embed fields are limited to 25 fields.
+
+        if (this.body.alerts) {
+            for (let i = 0; i < Math.min(this.body.alerts.length, 25); i++) {
+                // Get current Alert
+                const alert = this.body.alerts[i]
+
+                // Push alert to fieldArray
+                fieldArray.push({
+                    name: alert.labels.alertname,
+                    value: alert.annotations.description,
+                    inline: false,
+                })
+            }
+
+            return fieldArray
+        } else {
+            return []
+        }
+    }
+}

--- a/test/prometheus/prometheus-spec.ts
+++ b/test/prometheus/prometheus-spec.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai'
+import { Tester } from '../Tester'
+import { Prometheus } from '../../src/provider/Prometheus'
+
+describe('/POST prometheus', () => {
+    it('fires when called', async () => {
+        const res = await Tester.test(new Prometheus(), 'prometheus.json')
+        expect(res).to.not.be.null
+    })
+})

--- a/test/prometheus/prometheus.json
+++ b/test/prometheus/prometheus.json
@@ -1,0 +1,37 @@
+{
+  "receiver": "webhook",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "API Latency",
+        "dc": "eu-west-1",
+        "instance": "localhost:9090",
+        "job": "prometheus24"
+      },
+      "annotations": {
+        "description": "API has a latency of greater than 200ms"
+      },
+      "startsAt": "2018-08-03T09:52:26.739266876+02:00",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "http://example.com:9090/graph?g0.expr=go_memstats_alloc_bytes+%3E+0\u0026g0.tab=1"
+    }
+  ],
+  "groupLabels": {
+    "alertname": "API Latency",
+    "job": "prometheus24"
+  },
+  "commonLabels": {
+    "alertname": "Test",
+    "dc": "eu-west-1",
+    "instance": "localhost:9090",
+    "job": "prometheus24"
+  },
+  "commonAnnotations": {
+    "description": "some description"
+  },
+  "externalURL": "http://example.com:9093",
+  "version": "4",
+  "groupKey": "{}:{alertname=\"Test\", job=\"prometheus24\"}"
+}


### PR DESCRIPTION
Created a new provider for Prometheus.

What it looks like in discord:

![image](https://user-images.githubusercontent.com/11448029/143969149-2a49b88b-d98c-4b5f-9320-c197c40be42e.png)

Prometheus does not send headers, at least not that I could find in the documentation provided in #126 that's why I decided to set a `x-skyhook-event` header in the `Prometheus.ts` file.

Hope this helps!