### PR TITLE
Add rate limiting (5 req/s per webhook URL) using hono-rate-limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hono/node-server": "^2.0.3",
         "hono": "^4.12.31",
+        "hono-rate-limiter": "^0.5.3",
         "turndown": "^7.2.4"
       },
       "devDependencies": {
@@ -93,9 +94,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -113,9 +111,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -133,9 +128,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -153,9 +145,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -241,6 +230,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hono-rate-limiter": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/hono-rate-limiter/-/hono-rate-limiter-0.5.3.tgz",
+      "integrity": "sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": "^4.10.8",
+        "unstorage": "^1.17.3"
+      },
+      "peerDependenciesMeta": {
+        "unstorage": {
+          "optional": true
+        }
       }
     },
     "node_modules/turndown": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.3",
     "hono": "^4.12.31",
+    "hono-rate-limiter": "^0.5.3",
     "turndown": "^7.2.4"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { type Context, Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { cors } from 'hono/cors'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { rateLimiter } from 'hono-rate-limiter'
 import type { DiscordPayload } from './model/DiscordApi.ts'
 import { AppCenter } from './provider/AppCenter.ts'
 import { AppVeyor } from './provider/Appveyor.ts'
@@ -110,42 +111,62 @@ app.get('/api/webhooks/:webhookID/:webhookSecret/:from', (c) => {
     return c.body(null, 200)
 })
 
-app.post('/api/webhooks/:webhookID/:webhookSecret/:from', async (c) => {
-    const webhookID = c.req.param('webhookID')
-    const webhookSecret = c.req.param('webhookSecret')
-    const providerPath = c.req.param('from')
-    if (!webhookID || !webhookSecret || !providerPath) {
-        return c.body(null, 400)
-    }
-    const discordEndpoint = `https://discordapp.com/api/webhooks/${webhookID}/${webhookSecret}`
+app.post(
+    '/api/webhooks/:webhookID/:webhookSecret/:from',
+    rateLimiter({
+        windowMs: 1000, // 1 second
+        limit: 5, // 5 requests per second per webhook URL
+        keyGenerator: (c) => {
+            const webhookID = c.req.param('webhookID')
+            const webhookSecret = c.req.param('webhookSecret')
+            return `${webhookID}:${webhookSecret}`
+        },
+        message: 'Rate limit exceeded. Maximum 5 requests per second per webhook.',
+        statusCode: 429,
+        handler: (c, _next, _options) => {
+            logger.warn(`Rate limit exceeded for webhook: ${c.req.param('webhookID')}`)
+            return c.text('Rate limit exceeded. Maximum 5 requests per second per webhook.', 429, {
+                'Retry-After': '1',
+            })
+        },
+    }),
+    async (c) => {
+        const webhookID = c.req.param('webhookID')
+        const webhookSecret = c.req.param('webhookSecret')
+        const providerPath = c.req.param('from')
+        if (!webhookID || !webhookSecret || !providerPath) {
+            return c.body(null, 400)
+        }
+        const discordEndpoint = `https://discordapp.com/api/webhooks/${webhookID}/${webhookSecret}`
 
-    let discordPayload: DiscordPayload | null = null
+        let discordPayload: DiscordPayload | null = null
 
-    const Provider = providersMap.get(providerPath)
-    if (Provider == null) {
-        const errorMessage = `Unknown provider ${providerPath}`
-        logger.error(errorMessage)
-        return c.text(errorMessage, 400)
-    }
+        const Provider = providersMap.get(providerPath)
+        if (Provider == null) {
+            const errorMessage = `Unknown provider ${providerPath}`
+            logger.error(errorMessage)
+            return c.text(errorMessage, 400)
+        }
 
-    const instance = new Provider()
-    try {
-        const queryObject = c.req.query()
-        console.log(queryObject)
-        const headersObject: Record<string, string> = {}
-        c.req.raw.headers.forEach((value, key) => {
-            headersObject[key] = value
-        })
-        const body = await parseRequestBody(c)
-        discordPayload = await instance.parse(body, headersObject, queryObject)
-    } catch (error) {
-        logger.error('Error during parse: ' + error.stack)
-        discordPayload = ErrorUtil.createErrorPayload(providerPath, error)
-        return sendPayload(providerPath, discordPayload, discordEndpoint, c, 500)
-    }
+        const instance = new Provider()
+        try {
+            const queryObject = c.req.query()
+            console.log(queryObject)
+            const headersObject: Record<string, string> = {}
+            c.req.raw.headers.forEach((value, key) => {
+                headersObject[key] = value
+            })
+            const body = await parseRequestBody(c)
+            discordPayload = await instance.parse(body, headersObject, queryObject)
+        } catch (error) {
+            logger.error('Error during parse: ' + error.stack)
+            discordPayload = ErrorUtil.createErrorPayload(providerPath, error)
+            return sendPayload(providerPath, discordPayload, discordEndpoint, c, 500)
+        }
 
-    return sendPayload(providerPath, discordPayload, discordEndpoint, c)
-})
+        return sendPayload(providerPath, discordPayload, discordEndpoint, c)
+    },
+)
 
 app.post('/api/webhooks/:webhookID/:webhookSecret/:from/test', async (c) => {
     const webhookID = c.req.param('webhookID')


### PR DESCRIPTION
Uses the \`hono-rate-limiter\` library to add rate limiting to the webhook POST endpoint.

**Rate limiting config:**
- 5 requests per second per webhook URL (keyed on \`webhookID:webhookSecret\`)
- 1-second sliding window
- Returns 429 with \`Retry-After\` header on limit exceeded
- Logs rate limit violations

**Why per-webhook URL instead of IP?**
- Providers (GitHub, GitLab, etc.) can share IP ranges
- Keying on the webhook URL prevents a single Discord webhook from being spammed
- Each webhook URL maps to a unique Discord destination

**Addresses:** Security audit finding #5 (no rate limiting)