### PR TITLE
fix: put skyhook first in page title

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -45,7 +45,7 @@ const year = new Date().getFullYear()
 const SITE = Astro.site ?? new URL('https://www.skyhookapi.com')
 const canonical = new URL(base, SITE).href
 const ogImage = new URL(`${base}og.png`, SITE).href
-const pageTitle = 'Discord Notifications for Shopify, GitLab, Jira & 20+ Tools — skyhook'
+const pageTitle = 'skyhook — Discord Notifications for Shopify, GitLab, Jira & 20+ Tools'
 const pageDescription =
     'skyhook turns webhooks from Shopify, GitLab, Hugging Face, Jira, Docker Hub, CI tools and 20+ other services into clean, native Discord notifications — no bot to host, no code to write.'
 


### PR DESCRIPTION
The site title currently reads 'Discord Notifications for GitLab, Jira & 20+ Tools — skyhook'. This puts skyhook first so the brand leads: 'skyhook — Discord Notifications for GitLab, Jira & 20+ Tools'.