### PR TITLE
refactor: consolidate provider infrastructure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Skyhook happily accepts pull requests for new providers and features. To make th
 
 ### Code Style
 
-We have eslint configured for the project. If you are using VSCode (which you should, because it is awesome) and have the eslint plugin installed, you will be guided through the coding style and changes will be suggested. While writing your changes, please follow the code style maintained throughout the project. You should browse some of the existing code to get a feel of the style.
+Skyhook uses [Biome](https://biomejs.dev/) for formatting and linting. Run `npm run lint` before submitting a change and follow the style already used by nearby code.
 
 ### Working on Changes
 
@@ -18,9 +18,9 @@ Once you are satisfied with your changes, you may submit a [pull request](https:
 
 In order to test the features you've implemented, it's a good idea to setup and run skyhook locally.
 
-Ensure you have the latest version of Node.js installed and have cloned the repo. Open a command window in the root folder and run the command `npm install` to install the dependencies. From there you can start the server by simply running the command `npm start`.
+Use Node 24, as specified by `.nvmrc`, and clone the repository. Run `npm install` in the root folder, then use `npm run dev` while developing. `npm start` runs the compiled output and therefore requires `npm run build` first.
 
-In order to accept data from the webhook providers, you should forward the port which skyhook will bind to. By default, this is set to `8080`, however if another port is more convienient for you, you may change this in the code. **Be mindful not to submit this change in a pull request.**
+In order to accept data from webhook providers, forward the port Skyhook binds to. It defaults to `8080`; set the `PORT` environment variable if another port is more convenient.
 
 > If you are unable to forward a port you may use [ngrok](https://ngrok.com/).
 
@@ -30,5 +30,5 @@ From here you should be able to [setup](https://github.com/Commit451/skyhook#set
 
 If your changes work, the provider's webhooks should be parsed and forwarded to discord. You can also write tests in the `test` directory, using the other tests as an example, to make sure your webhook parsing is working.
 
-Each provider also needs one canonical payload under `examples/<provider>/` registered in `src/ProviderExamples.ts`. The hosted generator uses that same payload for the snackbar's **Test** action. Keep additional test-only payloads under `test/<provider>/`.
+Each provider also needs one canonical payload under `examples/<provider>/` and one explicit definition in `src/provider/ProviderRegistry.ts`. Live routing, `/api/providers`, and the hosted example action all derive from that registry. Keep additional test-only payloads under `test/<provider>/`; see [Creating a provider](docs/CreateNewProvider.md) for the complete checklist.
 

--- a/docs/CreateNewProvider.md
+++ b/docs/CreateNewProvider.md
@@ -1,55 +1,159 @@
-## Resources available in a provider class  
-`this.headers` - The headers of the request ([Reference](http://expressjs.com/de/4x/api.html#req))  
-`this.body` - only the body of the request object  
-`this.payload` - a [DiscordPayload](util/DiscordPayload.md)  
-`this.logger` - a [winston](https://github.com/winstonjs/winston) logger.
+# Creating a provider
 
-## Example for providers without multiple methods
+A provider converts one third-party webhook request into a Discord payload. The HTTP routes and packaged examples execute providers through `ProviderRunner`, so every request gets a fresh provider instance, asynchronous parsing is awaited, and the result is checked by the report-only Discord validator.
+
+## Provider state
+
+A provider receives these protected values before parsing:
+
+- `this.body` — parsed JSON or form body.
+- `this.headers` — request headers, or `null` in direct tests/examples without headers.
+- `this.query` — query parameters, or `null` when absent.
+- `this.payload` — the `DiscordPayload` being built.
+- `this.logger` — the shared Skyhook logger.
+
+Do not retain request data outside the provider instance. `ProviderRunner` constructs a fresh instance for every execution.
+
+## Direct providers
+
+Use `DirectParseProvider` when every webhook uses one parsing path:
+
 ```ts
-import { BaseProvider } from '../provider/BaseProvider.js'
+import { DirectParseProvider } from './BaseProvider.ts'
 
-class NewProvider extends BaseProvider {
-    static getName() {
-        return "{providerName}"
+export class NewProvider extends DirectParseProvider {
+    public getName(): string {
+        return 'NewProvider'
     }
-    
-    async parseData() {
-        //do your stuff here and add things to this.payload
+
+    // Override only when the public URL path is not getName().toLowerCase().
+    public getPath(): string {
+        return 'newprovider'
+    }
+
+    public async parseData(): Promise<void> {
+        if (this.body == null || typeof this.body !== 'object') {
+            this.nullifyPayload()
+            return
+        }
+
+        this.setEmbedColor(0x123456)
+        this.addEmbed({
+            title: 'New webhook event',
+            description: String(this.body.summary ?? ''),
+        })
     }
 }
-
-export { NewProvider }
-
 ```
 
-## Example for providers with multiple methods
+`parseData()` may perform asynchronous work. It must return a `Promise<void>`; do not start detached work after it returns. Bound every outbound request with an `AbortSignal` timeout. `addEmbed()` applies the shared Skyhook footer and configured color.
+
+Call `this.nullifyPayload()` for malformed, ignored, or unsupported input. Parsing then returns `null`, later lifecycle hooks are skipped safely, and the live endpoint responds with the existing unsupported-event text and HTTP 200.
+
+## Event-based providers
+
+Use `TypeParseProvider` when a header or body property selects an event handler:
+
 ```ts
-import { BaseProvider } from '../provider/BaseProvider.js'
+import { TypeParseProvider } from './BaseProvider.ts'
 
-class NewProvider extends BaseProvider {
-    constructor() {
-        super()
-        //do some stuff that should be available on all sub methods (e.g. setting the discord embed color)
-    }
-    
-    public static getName() {
-        return "{providerName}"
+export class NewProvider extends TypeParseProvider {
+    public getName(): string {
+        return 'NewProvider'
     }
 
-    public getType() {
-        //return the method that is used for this request.
-        //e.g. for GitLab we returning `this.body.object_kind`  
-        //if this.body.object_kind would be merge_request it would execute the sub method mergeRequest in this class here.
-        return {providerType};
+    public getType(): string | null {
+        return this.headers?.['x-new-provider-event'] ?? null
     }
 
-    //every type will be formated as camelCase
-    //e.g. merge_request will be mergeRequest
-    public async {typeName}() {
-        //do your stuff here and add things to this.payload
+    public knownTypes(): string[] {
+        return ['buildComplete', 'deploymentFailed']
+    }
+
+    public async buildComplete(): Promise<void> {
+        this.addEmbed({ title: 'Build completed' })
+    }
+
+    public async deploymentFailed(): Promise<void> {
+        this.addEmbed({ title: 'Deployment failed' })
     }
 }
+```
 
-export { NewProvider }
+`getType()` is normalized with `TypeParseProvider.formatType()`: colons, dots, underscores, hyphens, and spaces become a camel-cased handler name. For example, `build.complete` becomes `buildComplete`.
 
+Every callable event handler must be explicitly listed in `knownTypes()`. This list is the dispatch allowlist; unlisted events and listed events without a matching function are ignored. Keep labels, URLs, colors, and third-party interpretation inside the provider rather than in shared infrastructure.
+
+## Discord text and limits
+
+Use the semantic helpers instead of introducing provider-local copies:
+
+- `src/util/DiscordText.ts` — text cleanup, bounded truncation, literal Markdown escaping, and identifier humanization.
+- `src/util/DiscordEmbed.ts` — Discord limits, the shared Skyhook footer, and bounded literal embed fields.
+- `src/util/WebhookValue.ts` — record checks, scalar/identifier normalization, and strict ISO timestamp handling.
+
+Current shared limits are:
+
+- Message content: 2,000 characters.
+- Embeds per message: 10.
+- Text across all embeds in one message: 6,000 characters.
+- Embed title: 256; description: 4,096.
+- Field count: 25; field name: 256; field value: 1,024.
+- Author name: 256; footer text: 2,048.
+
+The 6,000-character budget applies to the combined title, description, author name, footer text, and field names/values across every embed in the message—not separately to each embed.
+
+`ProviderRunner` calls `validateDiscordPayload()` after a non-null parse and logs structured warnings. Validation is intentionally report-only: it does not mutate, truncate, split, reject, or repair legacy output. New providers should nevertheless produce clean validation results. Choose truncation, omission, splitting, or rejection deliberately for that provider rather than relying on the runner.
+
+Escape untrusted literal Markdown, but do not escape trusted Markdown that the provider intentionally constructs, such as its own links. Do not replace provider-specific HTML conversion unless tests prove the output is equivalent.
+
+## Registering the provider and example
+
+Provider registration is explicit; the runtime does not scan the provider directory.
+
+1. Add the provider source under `src/provider/`.
+2. Add one canonical body under `examples/<path>/`.
+3. Add canonical headers and query JSON files when the provider needs them.
+4. Import the provider in `src/provider/ProviderRegistry.ts`.
+5. Add one `ProviderDefinition` in the intended public order:
+
+```ts
+{
+    path: 'newprovider',
+    name: 'NewProvider',
+    provider: NewProvider,
+    example: {
+        body: 'newprovider/newprovider.json',
+        headers: 'newprovider/newprovider.headers.json', // optional
+        query: 'newprovider/newprovider.query.json',     // optional
+    },
+},
+```
+
+The registry rejects duplicate public paths and metadata that disagrees with `getPath()` or `getName()`. `/api/providers`, live routing, and example lookup all derive from this registry.
+
+Keep additional edge-case payloads under `test/<path>/`; only the canonical hosted example belongs under `examples/`.
+
+## Tests
+
+Add or update:
+
+- `test/<path>/<path>-spec.ts` with exact assertions for titles, descriptions, fields, author, URL, footer, and color—not only embed counts.
+- `test/provider/provider-registry-spec.ts` expected metadata.
+- `test/examples/examples-spec.ts` expected provider path order.
+
+Cover asynchronous completion, malformed input, unsupported events, provider-specific fallbacks, and Discord boundary behavior where relevant. Characterize odd legacy behavior before refactoring it.
+
+Use Node 24 (the version in `.nvmrc`) and run:
+
+```sh
+. "$HOME/.nvm/nvm.sh"
+nvm use 24
+npm test
+npm run lint
+npx tsc --noEmit
+npm run build
+cd web
+npm test
+npm run build
 ```

--- a/src/ProviderExamples.ts
+++ b/src/ProviderExamples.ts
@@ -1,12 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-
-type ProviderExampleFiles = {
-    body: string
-    headers?: string
-    query?: string
-}
+import { type ProviderRegistry, providerRegistry } from './provider/ProviderRegistry.ts'
 
 export type ProviderExample = {
     body: Record<string, unknown>
@@ -14,53 +9,15 @@ export type ProviderExample = {
     query: Record<string, string>
 }
 
-const providerExamples: Record<string, ProviderExampleFiles> = {
-    appcenter: { body: 'appcenter/appcenter-pipeline.json' },
-    appveyor: { body: 'appveyor/appveyor.json' },
-    basecamp: { body: 'basecamp/basecamp.json' },
-    bitbucket: {
-        body: 'bitbucket/bitbucket.json',
-        headers: 'bitbucket/bitbucket.headers.json',
-    },
-    bitbucketserver: {
-        body: 'bitbucketserver/bitbucketserver.json',
-        headers: 'bitbucketserver/bitbucketserver.headers.json',
-    },
-    circleci: { body: 'circleci/circleci.json' },
-    codacy: { body: 'codacy/codacy.json' },
-    confluence: { body: 'confluence/confluence_page.json' },
-    dockerhub: { body: 'dockerhub/dockerhub.json' },
-    gitlab: { body: 'gitlab/gitlab.json' },
-    heroku: { body: 'heroku/heroku.json' },
-    huggingface: { body: 'huggingface/huggingface.json' },
-    instana: { body: 'instana/instana.json' },
-    jenkins: { body: 'jenkins/jenkins.json' },
-    jira: { body: 'jira/jira-issue.json' },
-    newrelic: { body: 'newrelic/newrelic.json' },
-    patreon: {
-        body: 'patreon/patreon-member-create.json',
-        headers: 'patreon/patreon.headers.json',
-    },
-    pingdom: { body: 'pingdom/pingdom.json' },
-    rollbar: { body: 'rollbar/rollbar.json' },
-    shopify: {
-        body: 'shopify/shopify.json',
-        headers: 'shopify/shopify.headers.json',
-    },
-    travis: { body: 'travis/travis.json' },
-    trello: { body: 'trello/trello.json' },
-    unity: { body: 'unity/unity.json' },
-    uptimerobot: { body: 'uptimerobot/uptimerobot.json' },
-    vsts: { body: 'vsts/vsts.json' },
-    zendesk: { body: 'zendesk/zendesk.json' },
-}
-
 const examplesRoot = fileURLToPath(new URL('../examples/', import.meta.url))
 
-export const providerExamplePaths = Object.freeze(Object.keys(providerExamples))
+export const providerExamplePaths = Object.freeze(providerRegistry.definitions.map(({ path }) => path))
 
-export function loadProviderExample(providerPath: string): ProviderExample {
-    const files = providerExamples[providerPath]
+export function loadProviderExample(
+    providerPath: string,
+    registry: ProviderRegistry = providerRegistry,
+): ProviderExample {
+    const files = registry.get(providerPath)?.example
     if (files == null) {
         throw new Error(`No example payload is registered for provider ${providerPath}.`)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,34 +8,8 @@ import { cors } from 'hono/cors'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { rateLimiter } from 'hono-rate-limiter'
 import type { DiscordPayload } from './model/DiscordApi.ts'
-import { loadProviderExample } from './ProviderExamples.ts'
-import { AppCenter } from './provider/AppCenter.ts'
-import { AppVeyor } from './provider/Appveyor.ts'
-import { Basecamp } from './provider/Basecamp.ts'
-import type { BaseProvider } from './provider/BaseProvider.ts'
-import { BitBucketServer } from './provider/BitBucketServer.ts'
-import { BitBucket } from './provider/Bitbucket.ts'
-import { CircleCi } from './provider/CircleCi.ts'
-import { Codacy } from './provider/Codacy.ts'
-import { Confluence } from './provider/Confluence.ts'
-import { DockerHub } from './provider/DockerHub.ts'
-import { GitLab } from './provider/GitLab.ts'
-import { Heroku } from './provider/Heroku.ts'
-import { HuggingFace } from './provider/HuggingFace.ts'
-import { Instana } from './provider/Instana.ts'
-import { Jenkins } from './provider/Jenkins.ts'
-import { Jira } from './provider/Jira.ts'
-import { NewRelic } from './provider/NewRelic.ts'
-import { Patreon } from './provider/Patreon.ts'
-import { Pingdom } from './provider/Pingdom.ts'
-import { Rollbar } from './provider/Rollbar.ts'
-import { Shopify } from './provider/Shopify.ts'
-import { Travis } from './provider/Travis.ts'
-import { Trello } from './provider/Trello.ts'
-import { Unity } from './provider/Unity.ts'
-import { UptimeRobot } from './provider/UptimeRobot.ts'
-import { VSTS } from './provider/VSTS.ts'
-import { Zendesk } from './provider/Zendesk.ts'
+import { providerRegistry } from './provider/ProviderRegistry.ts'
+import { ProviderRunner } from './provider/ProviderRunner.ts'
 import { ErrorUtil } from './util/ErrorUtil.ts'
 import { logger } from './util/logger.ts'
 
@@ -43,47 +17,10 @@ logger.debug('Logger set up successfully.')
 
 export const app = new Hono()
 
-type ProviderClass = new () => BaseProvider
-
-const providers: ProviderClass[] = [
-    AppCenter,
-    AppVeyor,
-    Basecamp,
-    BitBucket,
-    BitBucketServer,
-    CircleCi,
-    Codacy,
-    Confluence,
-    DockerHub,
-    GitLab,
-    Heroku,
-    HuggingFace,
-    Instana,
-    Jenkins,
-    Jira,
-    NewRelic,
-    Patreon,
-    Pingdom,
-    Rollbar,
-    Shopify,
-    Travis,
-    Trello,
-    Unity,
-    UptimeRobot,
-    VSTS,
-    Zendesk,
-]
-
-const providersMap = new Map<string, ProviderClass>()
-const providerInfos: { name: string; path: string }[] = []
-for (const Provider of providers) {
-    const instance = new Provider()
-    providersMap.set(instance.getPath(), Provider)
-    logger.debug(`Adding provider: ${instance.getName()}`)
-    providerInfos.push({
-        name: instance.getName(),
-        path: instance.getPath(),
-    })
+const providerRunner = new ProviderRunner(providerRegistry)
+const DISCORD_WEBHOOK_TIMEOUT_MS = 10_000
+for (const { name } of providerRegistry.providerInfos) {
+    logger.debug(`Adding provider: ${name}`)
 }
 
 app.use('*', cors())
@@ -98,7 +35,7 @@ app.use('/*', serveStatic({ root: './public' }))
 
 app.get('/', (c) => c.redirect('https://www.skyhookapi.com/'))
 
-app.get('/api/providers', (c) => c.json(providerInfos, 200))
+app.get('/api/providers', (c) => c.json(providerRegistry.providerInfos, 200))
 
 const info = {
     version: process.env.K_REVISION,
@@ -142,7 +79,7 @@ const exampleAbuseRateLimiter = rateLimiter({
 app.get('/api/webhooks/:webhookID/:webhookSecret/:from', (c) => {
     // Return 200 if the provider is valid to show this url is ready.
     const provider = c.req.param('from')
-    if (provider == null || providersMap.get(provider) == null) {
+    if (provider == null || !providerRegistry.has(provider)) {
         const errorMessage = `Unknown provider ${provider}`
         logger.error(errorMessage)
         return c.text(errorMessage, 400)
@@ -161,25 +98,27 @@ app.post('/api/webhooks/:webhookID/:webhookSecret/:from', webhookRateLimiter, as
 
     let discordPayload: DiscordPayload | null = null
 
-    const Provider = providersMap.get(providerPath)
-    if (Provider == null) {
+    if (!providerRegistry.has(providerPath)) {
         const errorMessage = `Unknown provider ${providerPath}`
         logger.error(errorMessage)
         return c.text(errorMessage, 400)
     }
 
-    const instance = new Provider()
     try {
         const queryObject = c.req.query()
-        console.log(queryObject)
         const headersObject: Record<string, string> = {}
         c.req.raw.headers.forEach((value, key) => {
             headersObject[key] = value
         })
         const body = await parseRequestBody(c)
-        discordPayload = await instance.parse(body, headersObject, queryObject)
+        discordPayload = await providerRunner.run(providerPath, {
+            body,
+            headers: headersObject,
+            query: queryObject,
+        })
     } catch (error) {
-        logger.error('Error during parse: ' + error.stack)
+        const diagnostics = error instanceof Error ? (error.stack ?? error.message) : String(error)
+        logger.error(`Error during parse: ${diagnostics}`)
         discordPayload = ErrorUtil.createErrorPayload(providerPath, error)
         return sendPayload(providerPath, discordPayload, discordEndpoint, c, 500)
     }
@@ -195,17 +134,14 @@ const sendExampleWebhook = async (c: Context): Promise<Response> => {
         return c.body(null, 400)
     }
     const discordEndpoint = `https://discordapp.com/api/webhooks/${webhookID}/${webhookSecret}`
-    const Provider = providersMap.get(providerPath)
-    if (Provider == null) {
+    if (!providerRegistry.has(providerPath)) {
         const errorMessage = `Unknown provider ${providerPath}`
         logger.error(errorMessage)
         return c.text(errorMessage, 400)
     }
 
     try {
-        const provider = new Provider()
-        const example = loadProviderExample(providerPath)
-        const discordPayload = await provider.parse(example.body, example.headers, example.query)
+        const discordPayload = await providerRunner.runExample(providerPath)
         return sendPayload(providerPath, discordPayload, discordEndpoint, c)
     } catch (error) {
         logger.error(`Unable to create example payload for /${providerPath}: ${error}`)
@@ -312,7 +248,6 @@ async function sendPayload(
         logger.error('Discord payload is null')
         return c.text(`Webhook event is either not supported or not implemented by /${providerPath}.`, 200)
     }
-    // We could implement a more robust validation on this at some point.
     if (Object.keys(discordPayload).length === 0) {
         logger.error('Bad implementation, outbound payload is empty.')
         return c.text('Bad implementation.', 500)
@@ -325,6 +260,7 @@ async function sendPayload(
                 'Content-Type': 'application/json',
             },
             body: jsonString,
+            signal: AbortSignal.timeout(DISCORD_WEBHOOK_TIMEOUT_MS),
         })
         if (!response.ok) {
             const errorBody = await response.text()
@@ -332,8 +268,9 @@ async function sendPayload(
         }
         return c.body(null, upstreamStatusOverride ?? 200)
     } catch (err) {
-        logger.error(err)
-        return c.text(String(err), 500)
+        const diagnostics = err instanceof Error ? (err.stack ?? err.message) : String(err)
+        logger.error(diagnostics)
+        return c.text('Unable to deliver webhook.', 500)
     }
 }
 

--- a/src/provider/BaseProvider.ts
+++ b/src/provider/BaseProvider.ts
@@ -1,4 +1,5 @@
 import type { DiscordPayload, Embed } from '../model/DiscordApi.ts'
+import { SKYHOOK_FOOTER } from '../util/DiscordEmbed.ts'
 import { type Logger, logger } from '../util/logger.ts'
 
 function camelCase(s: string): string {
@@ -24,10 +25,12 @@ export abstract class BaseProvider {
     protected query: any
     // all embeds will use this color
     protected embedColor: number | null
+    private cancelled: boolean
 
     constructor() {
         this.payload = {}
         this.embedColor = null
+        this.cancelled = false
     }
 
     /**
@@ -53,24 +56,29 @@ export abstract class BaseProvider {
         this.body = body
         this.headers = headers
         this.query = query
-        this.preParse()
-        this.parseImpl()
-        this.postParse()
+        this.cancelled = false
+        await this.preParse()
+        if (this.cancelled) return null
 
-        return this.payload
+        await this.parseImpl()
+        if (this.cancelled) return null
+
+        await this.postParse()
+
+        return this.cancelled ? null : this.payload
     }
 
     /**
      * Nullify the payload. This will effectively cancel the operation and sent nothing to discord.
      */
     protected nullifyPayload(): void {
-        this.payload = null!
+        this.cancelled = true
     }
 
     /**
      * Open method to do certain things pre parse.
      */
-    protected preParse(): void {
+    protected preParse(): void | Promise<void> {
         // Default
     }
 
@@ -82,17 +90,16 @@ export abstract class BaseProvider {
     /**
      * Open method to do certain things post parse and before the payload is returned.
      */
-    protected postParse(): void {
+    protected postParse(): void | Promise<void> {
         // Default
     }
 
     protected addEmbed(embed: Embed): void {
+        if (this.cancelled) return
+
         // TODO check to see if too many fields
         // add the footer to all embeds added
-        embed.footer = {
-            text: 'Powered by skyhookapi.com',
-            icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
-        }
+        embed.footer = { ...SKYHOOK_FOOTER }
         if (this.embedColor != null) {
             embed.color = this.embedColor
         }

--- a/src/provider/BitBucketServer.ts
+++ b/src/provider/BitBucketServer.ts
@@ -4,24 +4,6 @@ import { TypeParseProvider } from './BaseProvider.ts'
 export class BitBucketServer extends TypeParseProvider {
     private embed: Embed
 
-    private static _formatLargeString(str: string, limit = 256): string {
-        return str.length > limit ? str.substring(0, limit - 1) + '\u2026' : str
-    }
-
-    private static _titleCase(str: string, ifNull = 'None'): string {
-        if (str == null) {
-            return ifNull
-        }
-        if (str.length < 1) {
-            return str
-        }
-        const strArray = str.toLowerCase().split(' ')
-        for (let i = 0; i < strArray.length; i++) {
-            strArray[i] = strArray[i].charAt(0).toUpperCase() + strArray[i].slice(1)
-        }
-        return strArray.join(' ')
-    }
-
     constructor() {
         super()
         this.setEmbedColor(0x205081)
@@ -81,7 +63,9 @@ export class BitBucketServer extends TypeParseProvider {
     public async repoRefsChanged(): Promise<void> {
         this.embed.author = this.extractAuthor()
         this.embed.title = `[${this.extractRepoRepositoryName()}] New commit`
-        this.embed.description = this.body.repository.description
+        if (typeof this.body.repository.description === 'string') {
+            this.embed.description = this.body.repository.description
+        }
         this.embed.url = this.extractRepoUrl()
         this.embed.fields = this.extractRepoChangesField()
         this.addEmbed(this.embed)

--- a/src/provider/CircleCi.ts
+++ b/src/provider/CircleCi.ts
@@ -19,8 +19,6 @@ export class CircleCi extends DirectParseProvider {
         const status = this.body.workflow.status
         const url = this.body.workflow.url
         const number = this.body.pipeline.number
-        console.log('sha:' + sha)
-
         let description = ''
         if (sha != null) {
             description += `[${sha.slice(0, 7)}]`

--- a/src/provider/Codacy.ts
+++ b/src/provider/Codacy.ts
@@ -20,13 +20,13 @@ export class Codacy extends DirectParseProvider {
         if (this.body.commit.results != null) {
             fields.push({
                 name: 'Fixed Issues',
-                value: this.body.commit.results.fixed_count || 0,
+                value: String(this.body.commit.results.fixed_count || 0),
                 inline: true,
             })
 
             fields.push({
                 name: 'New Issues',
-                value: this.body.commit.results.new_count || 0,
+                value: String(this.body.commit.results.new_count || 0),
                 inline: true,
             })
         }

--- a/src/provider/GitLab.ts
+++ b/src/provider/GitLab.ts
@@ -41,10 +41,6 @@ export class GitLab extends TypeParseProvider {
     }
 
     public async push(): Promise<void> {
-        const branch = this.body.ref.split('/')
-        branch.shift()
-        branch.shift()
-
         const project = this.projectFromBody()
 
         if (project.totalCommitsCount > 0) {

--- a/src/provider/HuggingFace.ts
+++ b/src/provider/HuggingFace.ts
@@ -1,8 +1,7 @@
 import type { Embed, EmbedField } from '../model/DiscordApi.ts'
+import { DISCORD_EMBED_LIMITS, DISCORD_MESSAGE_LIMITS, SKYHOOK_FOOTER_TEXT } from '../util/DiscordEmbed.ts'
 import { DirectParseProvider } from './BaseProvider.ts'
 
-const DISCORD_EMBED_CHARACTER_LIMIT = 6000
-const SKYHOOK_FOOTER_TEXT = 'Powered by skyhookapi.com'
 const CONTENT_SUMMARY_RESERVE = 64
 
 interface HuggingFaceUrl {
@@ -106,30 +105,36 @@ export class HuggingFace extends DirectParseProvider {
         const embed: Embed = { url: body.repo.url.web }
 
         if (body.event.action === 'move' && body.movedTo != null) {
-            embed.title = HuggingFace.truncate(`Moved ${body.repo.type} ${body.repo.name} to ${body.movedTo.name}`, 256)
+            embed.title = HuggingFace.truncate(
+                `Moved ${body.repo.type} ${body.repo.name} to ${body.movedTo.name}`,
+                DISCORD_EMBED_LIMITS.title,
+            )
             embed.description = `**New name:** \`${HuggingFace.escapeInlineCode(body.movedTo.name)}\``
             return embed
         }
 
-        embed.title = HuggingFace.truncate(`${action} ${body.repo.type} ${body.repo.name}`, 256)
+        embed.title = HuggingFace.truncate(`${action} ${body.repo.type} ${body.repo.name}`, DISCORD_EMBED_LIMITS.title)
         embed.description = `**Visibility:** ${body.repo.private ? 'Private' : 'Public'}`
         return embed
     }
 
     private formatRepoContent(body: HuggingFacePayload): Embed {
         const embed: Embed = {
-            title: HuggingFace.truncate(`Updated content in ${body.repo.type} ${body.repo.name}`, 256),
+            title: HuggingFace.truncate(
+                `Updated content in ${body.repo.type} ${body.repo.name}`,
+                DISCORD_EMBED_LIMITS.title,
+            ),
             url: body.repo.url.web,
         }
         const updatedRefs = body.updatedRefs ?? []
         const fields: EmbedField[] = []
         let remainingCharacters =
-            DISCORD_EMBED_CHARACTER_LIMIT -
+            DISCORD_MESSAGE_LIMITS.embedCharacters -
             (embed.title?.length ?? 0) -
             SKYHOOK_FOOTER_TEXT.length -
             CONTENT_SUMMARY_RESERVE
 
-        for (const updatedRef of updatedRefs.slice(0, 25)) {
+        for (const updatedRef of updatedRefs.slice(0, DISCORD_EMBED_LIMITS.fields)) {
             const field = this.formatUpdatedRef(body.repo, updatedRef)
             const fieldCharacters = field.name.length + field.value.length
             if (fieldCharacters > remainingCharacters) {
@@ -161,14 +166,17 @@ export class HuggingFace extends DirectParseProvider {
         ].filter((sha): sha is string => sha != null)
 
         return {
-            name: HuggingFace.truncate(`${change} ${kind} ${name}`, 256),
-            value: HuggingFace.truncate(shas.join(' → '), 1024),
+            name: HuggingFace.truncate(`${change} ${kind} ${name}`, DISCORD_EMBED_LIMITS.fieldName),
+            value: HuggingFace.truncate(shas.join(' → '), DISCORD_EMBED_LIMITS.fieldValue),
         }
     }
 
     private formatRepoConfig(body: HuggingFacePayload): Embed {
         return {
-            title: HuggingFace.truncate(`Updated settings for ${body.repo.type} ${body.repo.name}`, 256),
+            title: HuggingFace.truncate(
+                `Updated settings for ${body.repo.type} ${body.repo.name}`,
+                DISCORD_EMBED_LIMITS.title,
+            ),
             url: body.repo.url.web,
             description:
                 body.updatedConfig?.private == null
@@ -183,7 +191,7 @@ export class HuggingFace extends DirectParseProvider {
         const embed: Embed = {
             title: HuggingFace.truncate(
                 `${HuggingFace.actionLabel(body.event.action)} ${kind} #${discussion.num} on ${body.repo.name}: ${discussion.title}`,
-                256,
+                DISCORD_EMBED_LIMITS.title,
             ),
             url: discussion.url.web,
             fields: [
@@ -198,14 +206,17 @@ export class HuggingFace extends DirectParseProvider {
         if (discussion.changes?.base != null) {
             embed.fields!.push({
                 name: 'Base',
-                value: HuggingFace.truncate(HuggingFace.stripRefPrefix(discussion.changes.base), 1024),
+                value: HuggingFace.truncate(
+                    HuggingFace.stripRefPrefix(discussion.changes.base),
+                    DISCORD_EMBED_LIMITS.fieldValue,
+                ),
                 inline: true,
             })
         }
         if (body.comment?.hidden === true) {
             embed.description = 'This comment was hidden.'
         } else if (body.comment?.content != null) {
-            embed.description = HuggingFace.truncate(body.comment.content, 4096)
+            embed.description = HuggingFace.truncate(body.comment.content, DISCORD_EMBED_LIMITS.description)
         }
         return embed
     }
@@ -219,13 +230,13 @@ export class HuggingFace extends DirectParseProvider {
         return {
             title: HuggingFace.truncate(
                 `${action} comment on ${kind} #${discussion.num} in ${body.repo.name}: ${discussion.title}`,
-                256,
+                DISCORD_EMBED_LIMITS.title,
             ),
             url: comment.url.web,
             description:
                 comment.hidden || comment.content == null
                     ? 'This comment was hidden.'
-                    : HuggingFace.truncate(comment.content, 4096),
+                    : HuggingFace.truncate(comment.content, DISCORD_EMBED_LIMITS.description),
         }
     }
 
@@ -233,7 +244,7 @@ export class HuggingFace extends DirectParseProvider {
         return {
             title: HuggingFace.truncate(
                 `${HuggingFace.actionLabel(body.event.action)} ${body.event.scope} for ${body.repo.type} ${body.repo.name}`,
-                256,
+                DISCORD_EMBED_LIMITS.title,
             ),
             url: body.repo.url.web,
             description: 'A Hugging Face Hub event was received.',

--- a/src/provider/ProviderRegistry.ts
+++ b/src/provider/ProviderRegistry.ts
@@ -1,0 +1,266 @@
+import { AppCenter } from './AppCenter.ts'
+import { AppVeyor } from './Appveyor.ts'
+import { Basecamp } from './Basecamp.ts'
+import type { BaseProvider } from './BaseProvider.ts'
+import { BitBucketServer } from './BitBucketServer.ts'
+import { BitBucket } from './Bitbucket.ts'
+import { CircleCi } from './CircleCi.ts'
+import { Codacy } from './Codacy.ts'
+import { Confluence } from './Confluence.ts'
+import { DockerHub } from './DockerHub.ts'
+import { GitLab } from './GitLab.ts'
+import { Heroku } from './Heroku.ts'
+import { HuggingFace } from './HuggingFace.ts'
+import { Instana } from './Instana.ts'
+import { Jenkins } from './Jenkins.ts'
+import { Jira } from './Jira.ts'
+import { NewRelic } from './NewRelic.ts'
+import { Patreon } from './Patreon.ts'
+import { Pingdom } from './Pingdom.ts'
+import { Rollbar } from './Rollbar.ts'
+import { Shopify } from './Shopify.ts'
+import { Travis } from './Travis.ts'
+import { Trello } from './Trello.ts'
+import { Unity } from './Unity.ts'
+import { UptimeRobot } from './UptimeRobot.ts'
+import { VSTS } from './VSTS.ts'
+import { Zendesk } from './Zendesk.ts'
+
+export type ProviderConstructor = new () => BaseProvider
+
+export interface ProviderExampleFiles {
+    readonly body: string
+    readonly headers?: string
+    readonly query?: string
+}
+
+export interface ProviderDefinition {
+    readonly path: string
+    readonly name: string
+    readonly provider: ProviderConstructor
+    readonly example: ProviderExampleFiles
+}
+
+export interface ProviderInfo {
+    readonly name: string
+    readonly path: string
+}
+
+export class ProviderRegistry {
+    public readonly definitions: readonly ProviderDefinition[]
+    public readonly providerInfos: readonly ProviderInfo[]
+    private readonly definitionsByPath: ReadonlyMap<string, ProviderDefinition>
+
+    public constructor(definitions: readonly ProviderDefinition[]) {
+        const definitionsByPath = new Map<string, ProviderDefinition>()
+        const registeredDefinitions: ProviderDefinition[] = []
+
+        for (const input of definitions) {
+            if (definitionsByPath.has(input.path)) {
+                throw new Error(`Duplicate provider path "${input.path}".`)
+            }
+
+            const provider = new input.provider()
+            const providerPath = provider.getPath()
+            if (providerPath !== input.path) {
+                throw new Error(`Provider path "${input.path}" does not match "${providerPath}".`)
+            }
+            const providerName = provider.getName()
+            if (providerName !== input.name) {
+                throw new Error(`Provider name "${input.name}" does not match "${providerName}".`)
+            }
+
+            const definition = Object.freeze({
+                ...input,
+                example: Object.freeze({ ...input.example }),
+            })
+            definitionsByPath.set(definition.path, definition)
+            registeredDefinitions.push(definition)
+        }
+
+        this.definitionsByPath = definitionsByPath
+        this.definitions = Object.freeze(registeredDefinitions)
+        this.providerInfos = Object.freeze(registeredDefinitions.map(({ name, path }) => Object.freeze({ name, path })))
+    }
+
+    public get(path: string): ProviderDefinition | undefined {
+        return this.definitionsByPath.get(path)
+    }
+
+    public has(path: string): boolean {
+        return this.definitionsByPath.has(path)
+    }
+}
+
+const providerDefinitions: readonly ProviderDefinition[] = [
+    {
+        path: 'appcenter',
+        name: 'AppCenter',
+        provider: AppCenter,
+        example: { body: 'appcenter/appcenter-pipeline.json' },
+    },
+    {
+        path: 'appveyor',
+        name: 'AppVeyor',
+        provider: AppVeyor,
+        example: { body: 'appveyor/appveyor.json' },
+    },
+    {
+        path: 'basecamp',
+        name: 'Basecamp',
+        provider: Basecamp,
+        example: { body: 'basecamp/basecamp.json' },
+    },
+    {
+        path: 'bitbucket',
+        name: 'BitBucket',
+        provider: BitBucket,
+        example: {
+            body: 'bitbucket/bitbucket.json',
+            headers: 'bitbucket/bitbucket.headers.json',
+        },
+    },
+    {
+        path: 'bitbucketserver',
+        name: 'BitBucketServer',
+        provider: BitBucketServer,
+        example: {
+            body: 'bitbucketserver/bitbucketserver.json',
+            headers: 'bitbucketserver/bitbucketserver.headers.json',
+        },
+    },
+    {
+        path: 'circleci',
+        name: 'CircleCi',
+        provider: CircleCi,
+        example: { body: 'circleci/circleci.json' },
+    },
+    {
+        path: 'codacy',
+        name: 'Codacy',
+        provider: Codacy,
+        example: { body: 'codacy/codacy.json' },
+    },
+    {
+        path: 'confluence',
+        name: 'Confluence',
+        provider: Confluence,
+        example: { body: 'confluence/confluence_page.json' },
+    },
+    {
+        path: 'dockerhub',
+        name: 'DockerHub',
+        provider: DockerHub,
+        example: { body: 'dockerhub/dockerhub.json' },
+    },
+    {
+        path: 'gitlab',
+        name: 'GitLab',
+        provider: GitLab,
+        example: { body: 'gitlab/gitlab.json' },
+    },
+    {
+        path: 'heroku',
+        name: 'Heroku',
+        provider: Heroku,
+        example: { body: 'heroku/heroku.json' },
+    },
+    {
+        path: 'huggingface',
+        name: 'Hugging Face',
+        provider: HuggingFace,
+        example: { body: 'huggingface/huggingface.json' },
+    },
+    {
+        path: 'instana',
+        name: 'Instana',
+        provider: Instana,
+        example: { body: 'instana/instana.json' },
+    },
+    {
+        path: 'jenkins',
+        name: 'Jenkins-CI',
+        provider: Jenkins,
+        example: { body: 'jenkins/jenkins.json' },
+    },
+    {
+        path: 'jira',
+        name: 'Jira',
+        provider: Jira,
+        example: { body: 'jira/jira-issue.json' },
+    },
+    {
+        path: 'newrelic',
+        name: 'New Relic',
+        provider: NewRelic,
+        example: { body: 'newrelic/newrelic.json' },
+    },
+    {
+        path: 'patreon',
+        name: 'Patreon',
+        provider: Patreon,
+        example: {
+            body: 'patreon/patreon-member-create.json',
+            headers: 'patreon/patreon.headers.json',
+        },
+    },
+    {
+        path: 'pingdom',
+        name: 'Pingdom',
+        provider: Pingdom,
+        example: { body: 'pingdom/pingdom.json' },
+    },
+    {
+        path: 'rollbar',
+        name: 'Rollbar',
+        provider: Rollbar,
+        example: { body: 'rollbar/rollbar.json' },
+    },
+    {
+        path: 'shopify',
+        name: 'Shopify',
+        provider: Shopify,
+        example: {
+            body: 'shopify/shopify.json',
+            headers: 'shopify/shopify.headers.json',
+        },
+    },
+    {
+        path: 'travis',
+        name: 'Travis',
+        provider: Travis,
+        example: { body: 'travis/travis.json' },
+    },
+    {
+        path: 'trello',
+        name: 'Trello',
+        provider: Trello,
+        example: { body: 'trello/trello.json' },
+    },
+    {
+        path: 'unity',
+        name: 'Unity Cloud',
+        provider: Unity,
+        example: { body: 'unity/unity.json' },
+    },
+    {
+        path: 'uptimerobot',
+        name: 'Uptime Robot',
+        provider: UptimeRobot,
+        example: { body: 'uptimerobot/uptimerobot.json' },
+    },
+    {
+        path: 'vsts',
+        name: 'VSTS',
+        provider: VSTS,
+        example: { body: 'vsts/vsts.json' },
+    },
+    {
+        path: 'zendesk',
+        name: 'Zendesk',
+        provider: Zendesk,
+        example: { body: 'zendesk/zendesk.json' },
+    },
+]
+
+export const providerRegistry = new ProviderRegistry(providerDefinitions)

--- a/src/provider/ProviderRunner.ts
+++ b/src/provider/ProviderRunner.ts
@@ -1,0 +1,50 @@
+import type { DiscordPayload } from '../model/DiscordApi.ts'
+import { loadProviderExample } from '../ProviderExamples.ts'
+import { validateDiscordPayload } from '../util/DiscordPayloadValidator.ts'
+import { type Logger, logger } from '../util/logger.ts'
+import { type ProviderRegistry, providerRegistry } from './ProviderRegistry.ts'
+
+export interface ProviderRunInput {
+    readonly body: any
+    readonly headers?: any
+    readonly query?: any
+}
+
+type WarningLogger = Pick<Logger, 'warn'>
+
+export class ProviderRunner {
+    private readonly registry: ProviderRegistry
+    private readonly warningLogger: WarningLogger
+
+    public constructor(registry: ProviderRegistry = providerRegistry, warningLogger: WarningLogger = logger) {
+        this.registry = registry
+        this.warningLogger = warningLogger
+    }
+
+    public async run(providerPath: string, input: ProviderRunInput): Promise<DiscordPayload | null> {
+        const definition = this.registry.get(providerPath)
+        if (definition == null) {
+            throw new Error(`Unknown provider ${providerPath}`)
+        }
+
+        const provider = new definition.provider()
+        const payload = await provider.parse(input.body, input.headers ?? null, input.query ?? null)
+        if (payload != null) {
+            const issues = validateDiscordPayload(payload)
+            if (issues.length > 0) {
+                this.warningLogger.warn(
+                    JSON.stringify({
+                        event: 'discord_payload_validation_warning',
+                        provider: providerPath,
+                        issues,
+                    }),
+                )
+            }
+        }
+        return payload
+    }
+
+    public async runExample(providerPath: string): Promise<DiscordPayload | null> {
+        return this.run(providerPath, loadProviderExample(providerPath, this.registry))
+    }
+}

--- a/src/provider/Shopify.ts
+++ b/src/provider/Shopify.ts
@@ -1,13 +1,8 @@
 import type { Embed, EmbedField } from '../model/DiscordApi.ts'
 import { DirectParseProvider } from '../provider/BaseProvider.ts'
-
-const MAX_EMBED_CHARACTERS = 6000
-const MAX_TITLE_CHARACTERS = 256
-const MAX_FIELD_NAME_CHARACTERS = 256
-const MAX_FIELD_VALUE_CHARACTERS = 1024
-const MAX_FIELDS = 25
-const FOOTER_TEXT = 'Powered by skyhookapi.com'
-const ISO_8601_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|([+-])(\d{2}):(\d{2}))$/
+import { DISCORD_EMBED_LIMITS, fitLiteralEmbedFields } from '../util/DiscordEmbed.ts'
+import { cleanText, humanizeWords, truncateText } from '../util/DiscordText.ts'
+import { canonicalizeIso8601Timestamp, isRecord } from '../util/WebhookValue.ts'
 
 const ACTION_LABELS: Record<string, string> = {
     activate: 'activated',
@@ -104,7 +99,7 @@ export class Shopify extends DirectParseProvider {
         const label = this.getResourceLabel(resourcePart)
         const title = truncateText(
             `${resourceName} ${actionName}${label == null ? '' : `: ${label}`}`,
-            MAX_TITLE_CHARACTERS,
+            DISCORD_EMBED_LIMITS.title,
             true,
         )
 
@@ -129,7 +124,7 @@ export class Shopify extends DirectParseProvider {
         }
 
         const fields = this.createFields(resourcePart, actionPart)
-        embed.fields = fitFields(embed, fields)
+        embed.fields = fitLiteralEmbedFields(embed, fields)
 
         this.payload.allowed_mentions = { parse: [] }
         this.addEmbed(embed)
@@ -222,7 +217,7 @@ export class Shopify extends DirectParseProvider {
         for (const candidate of candidates) {
             const value = scalarText(candidate)
             if (value != null) {
-                const timestamp = canonicalizeTimestamp(value)
+                const timestamp = canonicalizeIso8601Timestamp(value)
                 if (timestamp != null) {
                     return timestamp
                 }
@@ -355,41 +350,6 @@ function humanizeResource(resource: string): string {
     return humanizeWords(words.join('_'))
 }
 
-function humanizeWords(value: string): string {
-    const words = cleanText(value, true)
-        .replace(/[._-]+/g, ' ')
-        .toLowerCase()
-    return words.length === 0 ? '' : words.charAt(0).toUpperCase() + words.slice(1)
-}
-
-function fitFields(embed: Embed, candidates: EmbedField[]): EmbedField[] {
-    let usedCharacters =
-        (embed.title?.length ?? 0) +
-        (embed.description?.length ?? 0) +
-        (embed.author?.name.length ?? 0) +
-        FOOTER_TEXT.length
-    const fields: EmbedField[] = []
-
-    for (const candidate of candidates.slice(0, MAX_FIELDS)) {
-        const name = truncateText(escapeDiscordMarkdown(candidate.name), MAX_FIELD_NAME_CHARACTERS, true)
-        const remainingCharacters = MAX_EMBED_CHARACTERS - usedCharacters - name.length
-        if (remainingCharacters <= 0) {
-            break
-        }
-        const value = truncateText(
-            escapeDiscordMarkdown(candidate.value),
-            Math.min(MAX_FIELD_VALUE_CHARACTERS, remainingCharacters),
-            false,
-        )
-        if (name.length === 0 || value.length === 0) {
-            continue
-        }
-        fields.push({ name, value, inline: candidate.inline })
-        usedCharacters += name.length + value.length
-    }
-    return fields
-}
-
 function safeId(value: unknown): string | null {
     if (typeof value === 'string') {
         const cleaned = cleanText(value, true)
@@ -412,86 +372,4 @@ function scalarText(value: unknown): string | null {
     }
     const text = cleanText(String(value), false)
     return text.length > 0 ? text : null
-}
-
-function escapeDiscordMarkdown(value: string): string {
-    return value.replace(/([\\`*_{}[\]()<>#+!|~])/g, '\\$1')
-}
-
-function canonicalizeTimestamp(value: string): string | null {
-    const match = ISO_8601_TIMESTAMP.exec(value)
-    if (match == null) {
-        return null
-    }
-
-    const [, yearText, monthText, dayText, hourText, minuteText, secondText, fractionText, zone, sign] = match
-    const year = Number(yearText)
-    const month = Number(monthText)
-    const day = Number(dayText)
-    const hour = Number(hourText)
-    const minute = Number(minuteText)
-    const second = Number(secondText)
-    const millisecond = Number(`${fractionText ?? ''}000`.slice(0, 3))
-    const offsetHour = zone === 'Z' ? 0 : Number(match[10])
-    const offsetMinute = zone === 'Z' ? 0 : Number(match[11])
-    if (
-        month < 1 ||
-        month > 12 ||
-        day < 1 ||
-        day > 31 ||
-        hour > 23 ||
-        minute > 59 ||
-        second > 59 ||
-        offsetHour > 23 ||
-        offsetMinute > 59
-    ) {
-        return null
-    }
-
-    const localDate = new Date(0)
-    localDate.setUTCFullYear(year, month - 1, day)
-    localDate.setUTCHours(hour, minute, second, millisecond)
-    if (
-        localDate.getUTCFullYear() !== year ||
-        localDate.getUTCMonth() !== month - 1 ||
-        localDate.getUTCDate() !== day ||
-        localDate.getUTCHours() !== hour ||
-        localDate.getUTCMinutes() !== minute ||
-        localDate.getUTCSeconds() !== second
-    ) {
-        return null
-    }
-
-    const offsetSign = sign === '-' ? -1 : 1
-    const offsetMilliseconds = offsetSign * (offsetHour * 60 + offsetMinute) * 60_000
-    return new Date(localDate.getTime() - offsetMilliseconds).toISOString()
-}
-
-function truncateText(value: string, maxLength: number, singleLine: boolean): string {
-    const cleaned = cleanText(value, singleLine)
-    if (cleaned.length <= maxLength) {
-        return cleaned
-    }
-    if (maxLength <= 1) {
-        return '…'.slice(0, maxLength)
-    }
-    return `${cleaned.slice(0, maxLength - 1)}…`
-}
-
-function cleanText(value: string, singleLine: boolean): string {
-    let cleaned = Array.from(value.replace(/\r\n?/g, '\n'))
-        .filter((character) => {
-            const code = character.charCodeAt(0)
-            return code === 9 || code === 10 || (code > 31 && code !== 127)
-        })
-        .join('')
-        .trim()
-    if (singleLine) {
-        cleaned = cleaned.replace(/\s+/g, ' ')
-    }
-    return cleaned
-}
-
-function isRecord(value: unknown): value is Record<string, any> {
-    return value != null && typeof value === 'object' && !Array.isArray(value)
 }

--- a/src/provider/Trello.ts
+++ b/src/provider/Trello.ts
@@ -7,6 +7,8 @@ type Card = any
 type Board = any
 type Attachment = any
 
+const PLUGIN_MANIFEST_TIMEOUT_MS = 10_000
+
 /**
  * https://developers.trello.com/apis/webhooks
  */
@@ -42,14 +44,8 @@ export class Trello extends TypeParseProvider {
         return str.length > limit ? str.substring(0, limit - 1) + '\u2026' : str
     }
 
-    private embed: Embed
     private action: any
     private model: any
-
-    constructor() {
-        super()
-        this.embed = {}
-    }
 
     public getName(): string {
         return 'Trello'
@@ -429,33 +425,7 @@ export class Trello extends TypeParseProvider {
     }
 
     public async disablePlugin(): Promise<void> {
-        const embed = this._preparePayload()
-        embed.url = this._resolveFullBoardURL(this.action.data.board)
-        const url = this.action.data.plugin.url
-        try {
-            const response = await fetch(url)
-            if (!response.ok) {
-                throw new Error(`Request failed with status ${response.status}`)
-            }
-            const manifest = await response.json()
-            const desc = MarkdownUtil._formatMarkdown(manifest.details, embed)
-            embed.title = '[' + this.action.data.board.name + '] Disabled Plugin \u2717'
-            embed.fields = [
-                {
-                    name: manifest.name,
-                    value: desc,
-                    inline: false,
-                },
-            ]
-            embed.image = {
-                url: new URL(manifest.icon.url, url).toString(),
-            }
-        } catch (err) {
-            console.log('[Trello Provider] Error while retrieving plugin manifest.')
-            console.log(err)
-            embed.title = '[' + this.action.data.board.name + '] Disabled Plugin "' + this.action.data.plugin.name + '"'
-        }
-        this.addEmbed(embed)
+        await this._formatPluginPayload('Disabled', '\u2717')
     }
 
     // How to Trigger?
@@ -471,17 +441,21 @@ export class Trello extends TypeParseProvider {
     }
 
     public async enablePlugin(): Promise<void> {
+        await this._formatPluginPayload('Enabled', '\u2713')
+    }
+
+    private async _formatPluginPayload(action: 'Enabled' | 'Disabled', mark: string): Promise<void> {
         const embed = this._preparePayload()
         embed.url = this._resolveFullBoardURL(this.action.data.board)
         const url = this.action.data.plugin.url
         try {
-            const response = await fetch(url)
+            const response = await fetch(url, { signal: AbortSignal.timeout(PLUGIN_MANIFEST_TIMEOUT_MS) })
             if (!response.ok) {
                 throw new Error(`Request failed with status ${response.status}`)
             }
             const manifest = await response.json()
             const desc = MarkdownUtil._formatMarkdown(manifest.details, embed)
-            embed.title = '[' + this.action.data.board.name + '] Enabled Plugin \u2713'
+            embed.title = `[${this.action.data.board.name}] ${action} Plugin ${mark}`
             embed.fields = [
                 {
                     name: manifest.name,
@@ -493,9 +467,9 @@ export class Trello extends TypeParseProvider {
                 url: new URL(manifest.icon.url, url).toString(),
             }
         } catch (err) {
-            console.log('[Trello Provider] Error while retrieving plugin manifest.')
-            console.log(err)
-            embed.title = '[' + this.action.data.board.name + '] Enabled Plugin "' + this.action.data.plugin.name + '"'
+            const diagnostics = err instanceof Error ? (err.stack ?? err.message) : String(err)
+            this.logger.warn(`[Trello Provider] Error while retrieving plugin manifest: ${diagnostics}`)
+            embed.title = `[${this.action.data.board.name}] ${action} Plugin "${this.action.data.plugin.name}"`
         }
         this.addEmbed(embed)
     }

--- a/src/provider/VSTS.ts
+++ b/src/provider/VSTS.ts
@@ -89,48 +89,24 @@ export class VSTS extends TypeParseProvider {
 
     // PULL REQUEST
     public async gitPullrequestCreated(): Promise<void> {
-        this.embed.author = this.extractCreatedByAuthor()
-        this.embed.fields = [
-            {
-                name: 'Pull Request from ' + this.body.resource.createdBy.displayName,
-                value:
-                    '([`' +
-                    this.body.resource.title +
-                    '`](' +
-                    this.body.resource.repository.remoteUrl +
-                    ')) ' +
-                    this.body.resource.description,
-                inline: false,
-            },
-        ]
-        this.addMinimalMessage()
+        this.formatPullRequest('Pull Request from ')
     }
 
     // PULL REQUEST MERGE COMMIT
     public async gitPullrequestMerged(): Promise<void> {
-        this.embed.author = this.extractCreatedByAuthor()
-        this.embed.fields = [
-            {
-                name: 'Pull Request Merge Commit from ' + this.body.resource.createdBy.displayName,
-                value:
-                    '([`' +
-                    this.body.resource.title +
-                    '`](' +
-                    this.body.resource.repository.remoteUrl +
-                    ')) ' +
-                    this.body.resource.description,
-                inline: false,
-            },
-        ]
-        this.addMinimalMessage()
+        this.formatPullRequest('Pull Request Merge Commit from ')
     }
 
     // PULL REQUEST UPDATED
     public async gitPullrequestUpdated(): Promise<void> {
+        this.formatPullRequest('Pull Request Updated by ')
+    }
+
+    private formatPullRequest(fieldLabel: string): void {
         this.embed.author = this.extractCreatedByAuthor()
         this.embed.fields = [
             {
-                name: 'Pull Request Updated by ' + this.body.resource.createdBy.displayName,
+                name: fieldLabel + this.body.resource.createdBy.displayName,
                 value:
                     '([`' +
                     this.body.resource.title +

--- a/src/provider/Zendesk.ts
+++ b/src/provider/Zendesk.ts
@@ -1,21 +1,14 @@
 import type { Embed, EmbedField } from '../model/DiscordApi.ts'
 import { DirectParseProvider } from '../provider/BaseProvider.ts'
+import { DISCORD_EMBED_LIMITS, fitLiteralEmbedFields } from '../util/DiscordEmbed.ts'
+import { cleanText, escapeDiscordMarkdownLiteral, humanizeWords, truncateText } from '../util/DiscordText.ts'
+import { canonicalizeIso8601Timestamp, isRecord } from '../util/WebhookValue.ts'
 
 const EVENT_TYPE_PREFIX = 'zen:event-type'
 const SUBJECT_DOMAIN_ALIASES: Record<string, readonly string[]> = {
     messaging_ticket: ['ticket'],
     omnichannel_config: ['account'],
 }
-const MAX_EMBED_CHARACTERS = 6000
-const MAX_TITLE_CHARACTERS = 256
-const MAX_DESCRIPTION_CHARACTERS = 4096
-const MAX_FIELD_NAME_CHARACTERS = 256
-const MAX_FIELD_VALUE_CHARACTERS = 1024
-const MAX_AUTHOR_NAME_CHARACTERS = 256
-const MAX_FIELDS = 25
-const FOOTER_TEXT = 'Powered by skyhookapi.com'
-const ISO_8601_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|([+-])(\d{2}):(\d{2}))$/
-
 /**
  * Converts Zendesk event-subscription webhooks into bounded Discord embeds.
  * Trigger and automation webhooks are intentionally excluded because Zendesk lets
@@ -88,14 +81,14 @@ export class Zendesk extends DirectParseProvider {
         const label = this.getResourceLabel(detail, event)
         const title = escapeAndTruncate(
             `${resourceName} ${actionName}${label == null ? '' : `: ${label}`}`,
-            MAX_TITLE_CHARACTERS,
+            DISCORD_EMBED_LIMITS.title,
             true,
         )
         const embed: Embed = { title }
 
         const description = this.getDescription(action, detail, event)
         if (description != null) {
-            embed.description = escapeAndTruncate(description, MAX_DESCRIPTION_CHARACTERS, false)
+            embed.description = escapeAndTruncate(description, DISCORD_EMBED_LIMITS.description, false)
         }
 
         const comment = isRecord(event.comment) ? event.comment : null
@@ -105,14 +98,14 @@ export class Zendesk extends DirectParseProvider {
             scalarText(actor?.name)
         if (authorName != null) {
             embed.author = {
-                name: escapeAndTruncate(authorName, MAX_AUTHOR_NAME_CHARACTERS, true),
+                name: escapeAndTruncate(authorName, DISCORD_EMBED_LIMITS.authorName, true),
             }
         }
 
         embed.timestamp = timestamp
 
         const fields = [...this.createEventFields(event), ...this.createResourceFields(resource, detail)]
-        embed.fields = fitFields(embed, fields)
+        embed.fields = fitLiteralEmbedFields(embed, fields)
 
         this.payload.allowed_mentions = { parse: [] }
         this.addEmbed(embed)
@@ -292,41 +285,6 @@ function humanizeListItem(value: string): string {
         .toLowerCase()
 }
 
-function humanizeWords(value: string): string {
-    const words = cleanText(value, true)
-        .replace(/[._-]+/g, ' ')
-        .toLowerCase()
-    return words.length === 0 ? '' : words.charAt(0).toUpperCase() + words.slice(1)
-}
-
-function fitFields(embed: Embed, candidates: EmbedField[]): EmbedField[] {
-    let usedCharacters =
-        (embed.title?.length ?? 0) +
-        (embed.description?.length ?? 0) +
-        (embed.author?.name.length ?? 0) +
-        FOOTER_TEXT.length
-    const fields: EmbedField[] = []
-
-    for (const candidate of candidates.slice(0, MAX_FIELDS)) {
-        const name = escapeAndTruncate(candidate.name, MAX_FIELD_NAME_CHARACTERS, true)
-        const remainingCharacters = MAX_EMBED_CHARACTERS - usedCharacters - name.length
-        if (remainingCharacters <= 0) {
-            break
-        }
-        const value = escapeAndTruncate(
-            candidate.value,
-            Math.min(MAX_FIELD_VALUE_CHARACTERS, remainingCharacters),
-            false,
-        )
-        if (name.length === 0 || value.length === 0) {
-            continue
-        }
-        fields.push({ name, value, inline: candidate.inline })
-        usedCharacters += name.length + value.length
-    }
-    return fields
-}
-
 function safeId(value: unknown): string | null {
     if (typeof value === 'string') {
         const cleaned = cleanText(value, true)
@@ -353,11 +311,7 @@ function scalarText(value: unknown): string | null {
 }
 
 function escapeAndTruncate(value: string, maxLength: number, singleLine: boolean): string {
-    return truncateText(escapeDiscordMarkdown(value), maxLength, singleLine)
-}
-
-function escapeDiscordMarkdown(value: string): string {
-    return value.replace(/([\\`*_{}[\]()<>#+!|~])/g, '\\$1')
+    return truncateText(escapeDiscordMarkdownLiteral(value), maxLength, singleLine)
 }
 
 function validateEnvelope(body: Record<string, any>): string | null {
@@ -376,90 +330,9 @@ function validateEnvelope(body: Record<string, any>): string | null {
     if (!isBoundedString(body.time, 64)) {
         return null
     }
-    return canonicalizeTimestamp(body.time)
+    return canonicalizeIso8601Timestamp(body.time)
 }
 
 function isBoundedString(value: unknown, maxLength: number): value is string {
     return typeof value === 'string' && value.length > 0 && value.length <= maxLength
-}
-
-function canonicalizeTimestamp(value: string | null): string | null {
-    if (value == null) {
-        return null
-    }
-    const match = ISO_8601_TIMESTAMP.exec(value)
-    if (match == null) {
-        return null
-    }
-
-    const [, yearText, monthText, dayText, hourText, minuteText, secondText, fractionText, zone, sign] = match
-    const year = Number(yearText)
-    const month = Number(monthText)
-    const day = Number(dayText)
-    const hour = Number(hourText)
-    const minute = Number(minuteText)
-    const second = Number(secondText)
-    const millisecond = Number(`${fractionText ?? ''}000`.slice(0, 3))
-    const offsetHour = zone === 'Z' ? 0 : Number(match[10])
-    const offsetMinute = zone === 'Z' ? 0 : Number(match[11])
-    if (
-        month < 1 ||
-        month > 12 ||
-        day < 1 ||
-        day > 31 ||
-        hour > 23 ||
-        minute > 59 ||
-        second > 59 ||
-        offsetHour > 23 ||
-        offsetMinute > 59
-    ) {
-        return null
-    }
-
-    const localDate = new Date(0)
-    localDate.setUTCFullYear(year, month - 1, day)
-    localDate.setUTCHours(hour, minute, second, millisecond)
-    if (
-        localDate.getUTCFullYear() !== year ||
-        localDate.getUTCMonth() !== month - 1 ||
-        localDate.getUTCDate() !== day ||
-        localDate.getUTCHours() !== hour ||
-        localDate.getUTCMinutes() !== minute ||
-        localDate.getUTCSeconds() !== second
-    ) {
-        return null
-    }
-
-    const offsetSign = sign === '-' ? -1 : 1
-    const offsetMilliseconds = offsetSign * (offsetHour * 60 + offsetMinute) * 60_000
-    return new Date(localDate.getTime() - offsetMilliseconds).toISOString()
-}
-
-function truncateText(value: string, maxLength: number, singleLine: boolean): string {
-    const cleaned = cleanText(value, singleLine)
-    if (cleaned.length <= maxLength) {
-        return cleaned
-    }
-    if (maxLength <= 1) {
-        return '…'.slice(0, maxLength)
-    }
-    return `${cleaned.slice(0, maxLength - 1)}…`
-}
-
-function cleanText(value: string, singleLine: boolean): string {
-    let cleaned = Array.from(value.replace(/\r\n?/g, '\n'))
-        .filter((character) => {
-            const code = character.charCodeAt(0)
-            return code === 9 || code === 10 || (code > 31 && code !== 127)
-        })
-        .join('')
-        .trim()
-    if (singleLine) {
-        cleaned = cleaned.replace(/\s+/g, ' ')
-    }
-    return cleaned
-}
-
-function isRecord(value: unknown): value is Record<string, any> {
-    return value != null && typeof value === 'object' && !Array.isArray(value)
 }

--- a/src/util/DiscordEmbed.ts
+++ b/src/util/DiscordEmbed.ts
@@ -1,0 +1,61 @@
+import type { Embed, EmbedField } from '../model/DiscordApi.ts'
+import { escapeDiscordMarkdownLiteral, truncateText } from './DiscordText.ts'
+
+export const DISCORD_MESSAGE_LIMITS = {
+    content: 2000,
+    embeds: 10,
+    embedCharacters: 6000,
+} as const
+
+export const DISCORD_EMBED_LIMITS = {
+    title: 256,
+    description: 4096,
+    fieldName: 256,
+    fieldValue: 1024,
+    authorName: 256,
+    footerText: 2048,
+    fields: 25,
+} as const
+
+export const SKYHOOK_FOOTER = {
+    text: 'Powered by skyhookapi.com',
+    icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+} as const
+
+export const SKYHOOK_FOOTER_TEXT = SKYHOOK_FOOTER.text
+
+export interface FitLiteralEmbedFieldsOptions {
+    footerText?: string
+}
+
+export function fitLiteralEmbedFields(
+    embed: Embed,
+    candidates: readonly EmbedField[],
+    { footerText = SKYHOOK_FOOTER_TEXT }: FitLiteralEmbedFieldsOptions = {},
+): EmbedField[] {
+    let usedCharacters =
+        (embed.title?.length ?? 0) +
+        (embed.description?.length ?? 0) +
+        (embed.author?.name.length ?? 0) +
+        footerText.length
+    const fields: EmbedField[] = []
+
+    for (const candidate of candidates.slice(0, DISCORD_EMBED_LIMITS.fields)) {
+        const name = truncateText(escapeDiscordMarkdownLiteral(candidate.name), DISCORD_EMBED_LIMITS.fieldName, true)
+        const remainingCharacters = DISCORD_MESSAGE_LIMITS.embedCharacters - usedCharacters - name.length
+        if (remainingCharacters <= 0) {
+            break
+        }
+        const value = truncateText(
+            escapeDiscordMarkdownLiteral(candidate.value),
+            Math.min(DISCORD_EMBED_LIMITS.fieldValue, remainingCharacters),
+            false,
+        )
+        if (name.length === 0 || value.length === 0) {
+            continue
+        }
+        fields.push({ name, value, inline: candidate.inline })
+        usedCharacters += name.length + value.length
+    }
+    return fields
+}

--- a/src/util/DiscordPayloadValidator.ts
+++ b/src/util/DiscordPayloadValidator.ts
@@ -1,0 +1,218 @@
+import { DISCORD_EMBED_LIMITS, DISCORD_MESSAGE_LIMITS } from './DiscordEmbed.ts'
+import { isRecord } from './WebhookValue.ts'
+
+export type DiscordPayloadValidationCode =
+    | 'payload-type'
+    | 'content-type'
+    | 'content-length'
+    | 'embeds-type'
+    | 'embed-count'
+    | 'embed-type'
+    | 'embed-title-type'
+    | 'embed-title-length'
+    | 'embed-description-type'
+    | 'embed-description-length'
+    | 'embed-author-type'
+    | 'embed-author-name-type'
+    | 'embed-author-name-length'
+    | 'embed-footer-type'
+    | 'embed-footer-text-type'
+    | 'embed-footer-text-length'
+    | 'embed-fields-type'
+    | 'embed-field-count'
+    | 'embed-field-type'
+    | 'embed-field-name-type'
+    | 'embed-field-name-length'
+    | 'embed-field-value-type'
+    | 'embed-field-value-length'
+    | 'embed-total-characters'
+
+export interface DiscordPayloadValidationIssue {
+    code: DiscordPayloadValidationCode
+    path: string
+    actual?: number
+    limit?: number
+}
+
+export function validateDiscordPayload(payload: unknown): DiscordPayloadValidationIssue[] {
+    const issues: DiscordPayloadValidationIssue[] = []
+    if (!isRecord(payload)) {
+        return [{ code: 'payload-type', path: '$' }]
+    }
+
+    if (hasOwn(payload, 'content')) {
+        validateText(
+            payload.content,
+            'content',
+            DISCORD_MESSAGE_LIMITS.content,
+            'content-type',
+            'content-length',
+            issues,
+        )
+    }
+
+    if (!hasOwn(payload, 'embeds')) {
+        return issues
+    }
+    if (!Array.isArray(payload.embeds)) {
+        issues.push({ code: 'embeds-type', path: 'embeds' })
+        return issues
+    }
+    if (payload.embeds.length > DISCORD_MESSAGE_LIMITS.embeds) {
+        issues.push({
+            code: 'embed-count',
+            path: 'embeds',
+            actual: payload.embeds.length,
+            limit: DISCORD_MESSAGE_LIMITS.embeds,
+        })
+    }
+
+    let totalEmbedCharacters = 0
+    for (const [embedIndex, embed] of payload.embeds.entries()) {
+        const embedPath = `embeds[${embedIndex}]`
+        if (!isRecord(embed)) {
+            issues.push({ code: 'embed-type', path: embedPath })
+            continue
+        }
+
+        if (hasOwn(embed, 'title')) {
+            totalEmbedCharacters += validateText(
+                embed.title,
+                `${embedPath}.title`,
+                DISCORD_EMBED_LIMITS.title,
+                'embed-title-type',
+                'embed-title-length',
+                issues,
+            )
+        }
+        if (hasOwn(embed, 'description')) {
+            totalEmbedCharacters += validateText(
+                embed.description,
+                `${embedPath}.description`,
+                DISCORD_EMBED_LIMITS.description,
+                'embed-description-type',
+                'embed-description-length',
+                issues,
+            )
+        }
+        if (hasOwn(embed, 'author')) {
+            totalEmbedCharacters += validateNestedText(
+                embed.author,
+                'name',
+                `${embedPath}.author`,
+                DISCORD_EMBED_LIMITS.authorName,
+                'embed-author-type',
+                'embed-author-name-type',
+                'embed-author-name-length',
+                issues,
+            )
+        }
+        if (hasOwn(embed, 'footer')) {
+            totalEmbedCharacters += validateNestedText(
+                embed.footer,
+                'text',
+                `${embedPath}.footer`,
+                DISCORD_EMBED_LIMITS.footerText,
+                'embed-footer-type',
+                'embed-footer-text-type',
+                'embed-footer-text-length',
+                issues,
+            )
+        }
+        if (hasOwn(embed, 'fields')) {
+            totalEmbedCharacters += validateFields(embed.fields, embedPath, issues)
+        }
+    }
+
+    if (totalEmbedCharacters > DISCORD_MESSAGE_LIMITS.embedCharacters) {
+        issues.push({
+            code: 'embed-total-characters',
+            path: 'embeds',
+            actual: totalEmbedCharacters,
+            limit: DISCORD_MESSAGE_LIMITS.embedCharacters,
+        })
+    }
+
+    return issues
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+    return Object.hasOwn(value, key)
+}
+
+function validateText(
+    value: unknown,
+    path: string,
+    limit: number,
+    typeCode: DiscordPayloadValidationCode,
+    lengthCode: DiscordPayloadValidationCode,
+    issues: DiscordPayloadValidationIssue[],
+): number {
+    if (typeof value !== 'string') {
+        issues.push({ code: typeCode, path })
+        return 0
+    }
+    if (value.length > limit) {
+        issues.push({ code: lengthCode, path, actual: value.length, limit })
+    }
+    return value.length
+}
+
+function validateNestedText(
+    value: unknown,
+    key: string,
+    path: string,
+    limit: number,
+    recordTypeCode: DiscordPayloadValidationCode,
+    textTypeCode: DiscordPayloadValidationCode,
+    lengthCode: DiscordPayloadValidationCode,
+    issues: DiscordPayloadValidationIssue[],
+): number {
+    if (!isRecord(value)) {
+        issues.push({ code: recordTypeCode, path })
+        return 0
+    }
+    return validateText(value[key], `${path}.${key}`, limit, textTypeCode, lengthCode, issues)
+}
+
+function validateFields(value: unknown, embedPath: string, issues: DiscordPayloadValidationIssue[]): number {
+    const fieldsPath = `${embedPath}.fields`
+    if (!Array.isArray(value)) {
+        issues.push({ code: 'embed-fields-type', path: fieldsPath })
+        return 0
+    }
+    if (value.length > DISCORD_EMBED_LIMITS.fields) {
+        issues.push({
+            code: 'embed-field-count',
+            path: fieldsPath,
+            actual: value.length,
+            limit: DISCORD_EMBED_LIMITS.fields,
+        })
+    }
+
+    let characters = 0
+    for (const [fieldIndex, field] of value.entries()) {
+        const fieldPath = `${fieldsPath}[${fieldIndex}]`
+        if (!isRecord(field)) {
+            issues.push({ code: 'embed-field-type', path: fieldPath })
+            continue
+        }
+        characters += validateText(
+            field.name,
+            `${fieldPath}.name`,
+            DISCORD_EMBED_LIMITS.fieldName,
+            'embed-field-name-type',
+            'embed-field-name-length',
+            issues,
+        )
+        characters += validateText(
+            field.value,
+            `${fieldPath}.value`,
+            DISCORD_EMBED_LIMITS.fieldValue,
+            'embed-field-value-type',
+            'embed-field-value-length',
+            issues,
+        )
+    }
+    return characters
+}

--- a/src/util/DiscordText.ts
+++ b/src/util/DiscordText.ts
@@ -1,0 +1,35 @@
+export function cleanText(value: string, singleLine: boolean): string {
+    let cleaned = Array.from(value.replace(/\r\n?/g, '\n'))
+        .filter((character) => {
+            const code = character.charCodeAt(0)
+            return code === 9 || code === 10 || (code > 31 && code !== 127)
+        })
+        .join('')
+        .trim()
+    if (singleLine) {
+        cleaned = cleaned.replace(/\s+/g, ' ')
+    }
+    return cleaned
+}
+
+export function truncateText(value: string, maxLength: number, singleLine: boolean): string {
+    const cleaned = cleanText(value, singleLine)
+    if (cleaned.length <= maxLength) {
+        return cleaned
+    }
+    if (maxLength <= 1) {
+        return '…'.slice(0, maxLength)
+    }
+    return `${cleaned.slice(0, maxLength - 1)}…`
+}
+
+export function escapeDiscordMarkdownLiteral(value: string): string {
+    return value.replace(/([\\`*_{}[\]()<>#+!|~])/g, '\\$1')
+}
+
+export function humanizeWords(value: string): string {
+    const words = cleanText(value, true)
+        .replace(/[._-]+/g, ' ')
+        .toLowerCase()
+    return words.length === 0 ? '' : words.charAt(0).toUpperCase() + words.slice(1)
+}

--- a/src/util/ErrorUtil.ts
+++ b/src/util/ErrorUtil.ts
@@ -1,16 +1,16 @@
 import type { DiscordPayload } from '../model/DiscordApi.ts'
 
 /**
- * Error things
+ * Builds the safe Discord-facing payload for an internal parse failure.
  */
 export class ErrorUtil {
-    public static createErrorPayload(provider: string, error: Error): DiscordPayload {
+    public static createErrorPayload(provider: string, _error: unknown): DiscordPayload {
         return {
             embeds: [
                 {
                     title: 'Skyhook Error',
                     url: 'https://github.com/Commit451/skyhook/issues',
-                    description: `An error has occured on skyhook for your webhook with provider ${provider}. Maybe you can copy/paste or screenshot this error if there is no sensitive information and open an issue on the skyhook GitHub.\n\nError: ${JSON.stringify(error.stack)}`,
+                    description: `An error occurred in Skyhook while processing your webhook for provider ${provider}. Internal error and request details are only recorded in the server logs. Please open an issue on the Skyhook GitHub if the problem continues.`,
                 },
             ],
         }

--- a/src/util/WebhookValue.ts
+++ b/src/util/WebhookValue.ts
@@ -1,0 +1,57 @@
+const ISO_8601_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|([+-])(\d{2}):(\d{2}))$/
+
+export function isRecord(value: unknown): value is Record<string, any> {
+    return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function canonicalizeIso8601Timestamp(value: unknown): string | null {
+    if (typeof value !== 'string') {
+        return null
+    }
+    const match = ISO_8601_TIMESTAMP.exec(value)
+    if (match == null) {
+        return null
+    }
+
+    const [, yearText, monthText, dayText, hourText, minuteText, secondText, fractionText, zone, sign] = match
+    const year = Number(yearText)
+    const month = Number(monthText)
+    const day = Number(dayText)
+    const hour = Number(hourText)
+    const minute = Number(minuteText)
+    const second = Number(secondText)
+    const millisecond = Number(`${fractionText ?? ''}000`.slice(0, 3))
+    const offsetHour = zone === 'Z' ? 0 : Number(match[10])
+    const offsetMinute = zone === 'Z' ? 0 : Number(match[11])
+    if (
+        month < 1 ||
+        month > 12 ||
+        day < 1 ||
+        day > 31 ||
+        hour > 23 ||
+        minute > 59 ||
+        second > 59 ||
+        offsetHour > 23 ||
+        offsetMinute > 59
+    ) {
+        return null
+    }
+
+    const localDate = new Date(0)
+    localDate.setUTCFullYear(year, month - 1, day)
+    localDate.setUTCHours(hour, minute, second, millisecond)
+    if (
+        localDate.getUTCFullYear() !== year ||
+        localDate.getUTCMonth() !== month - 1 ||
+        localDate.getUTCDate() !== day ||
+        localDate.getUTCHours() !== hour ||
+        localDate.getUTCMinutes() !== minute ||
+        localDate.getUTCSeconds() !== second
+    ) {
+        return null
+    }
+
+    const offsetSign = sign === '-' ? -1 : 1
+    const offsetMilliseconds = offsetSign * (offsetHour * 60 + offsetMinute) * 60_000
+    return new Date(localDate.getTime() - offsetMilliseconds).toISOString()
+}

--- a/test/Tester.ts
+++ b/test/Tester.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { inspect } from 'node:util'
 import type { DiscordPayload } from '../src/model/DiscordApi.ts'
 import type { BaseProvider } from '../src/provider/BaseProvider.ts'
 
@@ -28,7 +27,6 @@ class Tester {
     ): Promise<DiscordPayload | null> {
         try {
             const res = await provider.parse(body, headers, query)
-            console.log(inspect(res, false, null, true))
             return Promise.resolve(res)
         } catch (err) {
             console.error(err)

--- a/test/api/example-webhook-spec.ts
+++ b/test/api/example-webhook-spec.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict'
 import { afterEach, describe, it, mock } from 'node:test'
 import { app } from '../../src/index.ts'
+import { validateDiscordPayload } from '../../src/util/DiscordPayloadValidator.ts'
+import { logger } from '../../src/util/logger.ts'
 
 type Delivery = {
     url: string
@@ -13,6 +15,11 @@ afterEach(() => mock.restoreAll())
 describe('example webhook API', () => {
     it('parses and sends the packaged example for every advertised provider', async () => {
         const deliveries: Delivery[] = []
+        const validationWarnings: string[] = []
+        mock.method(logger, 'warn', (message: unknown) => {
+            const text = String(message)
+            if (text.includes('discord_payload_validation_warning')) validationWarnings.push(text)
+        })
         mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
             deliveries.push({
                 url: String(input),
@@ -38,8 +45,11 @@ describe('example webhook API', () => {
             assert.equal(delivery.url, `https://discordapp.com/api/webhooks/example-${index}/secret`)
             assert.equal(delivery.method, 'POST')
             assert.ok(delivery.body)
-            assert.notDeepEqual(JSON.parse(delivery.body), {})
+            const payload = JSON.parse(delivery.body)
+            assert.notDeepEqual(payload, {})
+            assert.deepEqual(validateDiscordPayload(payload), [], providers[index].path)
         }
+        assert.deepEqual(validationWarnings, [])
     })
 
     it('keeps the existing test route as a compatibility alias', async () => {
@@ -59,6 +69,59 @@ describe('example webhook API', () => {
         assert.equal(response.status, 400)
         assert.match(await response.text(), /Unknown provider/)
         assert.equal(fetchMock.mock.callCount(), 0)
+    })
+
+    it('delivers a sanitized live parse error while logging full diagnostics server-side', async () => {
+        const deliveries: string[] = []
+        const diagnostics: unknown[] = []
+        mock.method(globalThis, 'fetch', async (_input: string | URL | Request, init?: RequestInit) => {
+            if (typeof init?.body === 'string') deliveries.push(init.body)
+            return new Response(null, { status: 204 })
+        })
+        mock.method(logger, 'error', (message: unknown) => diagnostics.push(message))
+
+        const response = await app.request('/api/webhooks/parse-error/secret/gitlab', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: '{"private-request-fragment":',
+        })
+
+        assert.equal(response.status, 500)
+        assert.equal(deliveries.length, 1)
+        const deliveredPayload = JSON.parse(deliveries[0])
+        const deliveredText = JSON.stringify(deliveredPayload)
+        assert.equal(deliveredPayload.embeds?.[0]?.title, 'Skyhook Error')
+        assert.match(deliveredPayload.embeds?.[0]?.description ?? '', /gitlab/)
+        assert.doesNotMatch(deliveredText, /private-request-fragment/)
+        assert.doesNotMatch(deliveredText, /SyntaxError|Unexpected|JSON\.parse|src\/index/i)
+
+        const loggedText = diagnostics.map(String).join('\n')
+        assert.match(loggedText, /Error during parse:/)
+        assert.match(loggedText, /SyntaxError|JSON|Unexpected/i)
+    })
+
+    it('bounds Discord delivery time and keeps upstream failure details out of the response', async () => {
+        const diagnostics: unknown[] = []
+        let deliverySignal: AbortSignal | null | undefined
+        mock.method(globalThis, 'fetch', async (_input: string | URL | Request, init?: RequestInit) => {
+            deliverySignal = init?.signal
+            return new Response('private Discord diagnostic', { status: 400 })
+        })
+        mock.method(logger, 'error', (message: unknown) => diagnostics.push(message))
+
+        const response = await app.request('/api/webhooks/delivery-failure/secret/gitlab/example', {
+            method: 'POST',
+        })
+
+        assert.equal(response.status, 500)
+        const responseText = await response.text()
+        assert.equal(responseText, 'Unable to deliver webhook.')
+        assert.ok(deliverySignal instanceof AbortSignal)
+        assert.doesNotMatch(responseText, /private Discord diagnostic|Discord webhook responded/i)
+        assert.match(
+            diagnostics.map(String).join('\n'),
+            /Discord webhook responded with 400: private Discord diagnostic/,
+        )
     })
 
     it('shares the webhook delivery rate limit with example pushes', async () => {

--- a/test/bitbucketserver/bitbucketserver-spec.ts
+++ b/test/bitbucketserver/bitbucketserver-spec.ts
@@ -13,6 +13,26 @@ describe('/POST bitbucketserver', () => {
         assert.notStrictEqual(res, null)
         assert.ok(Array.isArray(res!.embeds))
         assert.strictEqual(res!.embeds.length, 1)
+        const embed = res!.embeds[0]
+        assert.equal(embed.title, '[repository] New commit')
+        assert.equal(embed.url, 'https://bitbucket.domain.com/projects/PROJ/repos/repository/browse')
+        assert.deepEqual(embed.author, {
+            name: 'Administrator',
+            icon_url: 'https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/44_Bitbucket_logo_logos-512.png',
+        })
+        assert.equal(Object.hasOwn(embed, 'description'), false)
+        assert.deepEqual(
+            embed.fields,
+            Array.from({ length: 18 }, () => ({
+                name: 'Change',
+                value: '**Branch:** master \n **Old Hash:** ecddabb624 \n **New Hash:** 178864a7d5 \n **Type:** UPDATE',
+            })),
+        )
+        assert.deepEqual(embed.footer, {
+            text: 'Powered by skyhookapi.com',
+            icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+        })
+        assert.equal(embed.color, 0x205081)
     })
 
     it('repo:refs_changed 18 fields or less', async () => {

--- a/test/codacy/codacy-spec.ts
+++ b/test/codacy/codacy-spec.ts
@@ -4,10 +4,37 @@ import { Codacy } from '../../src/provider/Codacy.ts'
 import { Tester } from '../Tester.ts'
 
 describe('/POST codacy', () => {
-    it('commit', async () => {
+    it('formats a commit exactly', async () => {
+        const res = await Tester.test(new Codacy(), 'codacy.json', null)
+
+        assert.deepStrictEqual(res, {
+            embeds: [
+                {
+                    title: 'New Commit',
+                    url: 'https://www.codacy.com/public/jquery/jquery.git/commit?bid=21776&cid=6037089',
+                    fields: [
+                        { name: 'Fixed Issues', value: '1', inline: true },
+                        { name: 'New Issues', value: '0', inline: true },
+                    ],
+                    footer: {
+                        text: 'Powered by skyhookapi.com',
+                        icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+                    },
+                    color: 0x242c33,
+                },
+            ],
+        })
+    })
+
+    it('emits string field names and values', async () => {
         const res = await Tester.test(new Codacy(), 'codacy.json', null)
         assert.notStrictEqual(res, null)
-        assert.ok(Array.isArray(res!.embeds))
-        assert.strictEqual(res!.embeds.length, 1)
+
+        for (const embed of res!.embeds ?? []) {
+            for (const field of embed.fields ?? []) {
+                assert.strictEqual(typeof field.name, 'string')
+                assert.strictEqual(typeof field.value, 'string')
+            }
+        }
     })
 })

--- a/test/examples/examples-spec.ts
+++ b/test/examples/examples-spec.ts
@@ -1,6 +1,22 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { loadProviderExample, providerExamplePaths } from '../../src/ProviderExamples.ts'
+import { DirectParseProvider } from '../../src/provider/BaseProvider.ts'
+import { ProviderRegistry, providerRegistry } from '../../src/provider/ProviderRegistry.ts'
+
+class ExampleAliasProvider extends DirectParseProvider {
+    public getName(): string {
+        return 'Example Alias'
+    }
+
+    public getPath(): string {
+        return 'example-alias'
+    }
+
+    public async parseData(): Promise<void> {
+        this.payload.content = 'example'
+    }
+}
 
 const expectedProviderPaths = [
     'appcenter',
@@ -34,12 +50,31 @@ const expectedProviderPaths = [
 describe('provider examples', () => {
     it('packages one loadable local example for every registered provider', () => {
         assert.deepEqual(providerExamplePaths, expectedProviderPaths)
+        assert.deepEqual(
+            providerExamplePaths,
+            providerRegistry.definitions.map(({ path }) => path),
+        )
 
         for (const providerPath of providerExamplePaths) {
             const example = loadProviderExample(providerPath)
             assert.equal(typeof example.body, 'object', providerPath)
             assert.notEqual(example.body, null, providerPath)
         }
+    })
+
+    it('resolves example files from the supplied registry', () => {
+        const registry = new ProviderRegistry([
+            {
+                path: 'example-alias',
+                name: 'Example Alias',
+                provider: ExampleAliasProvider,
+                example: { body: 'gitlab/gitlab.json' },
+            },
+        ])
+
+        const example = loadProviderExample('example-alias', registry)
+
+        assert.equal(example.body.object_kind, 'push')
     })
 
     it('rejects unknown providers instead of constructing a path from user input', () => {

--- a/test/gitlab/gitlab-spec.ts
+++ b/test/gitlab/gitlab-spec.ts
@@ -9,5 +9,31 @@ describe('/POST gitlab', () => {
         assert.notStrictEqual(res, null)
         assert.ok(Array.isArray(res!.embeds))
         assert.strictEqual(res!.embeds.length, 1)
+        assert.deepEqual(res!.embeds[0], {
+            title: '[Diaspora:master] 4 commits',
+            url: 'http://example.com/mike/diaspora/tree/master',
+            fields: [
+                {
+                    name: 'Commit from Jordi Mallach',
+                    value: '([`b6568db`](http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327)) Update Catalan translation to e38cb41.',
+                    inline: false,
+                },
+                {
+                    name: 'Commit from GitLab dev user',
+                    value: '([`da15608`](http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7)) fixed readme',
+                    inline: false,
+                },
+            ],
+            author: {
+                name: 'John Smith',
+                icon_url:
+                    'https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80',
+            },
+            footer: {
+                text: 'Powered by skyhookapi.com',
+                icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+            },
+            color: 0xfca326,
+        })
     })
 })

--- a/test/patreon/patreon-spec.ts
+++ b/test/patreon/patreon-spec.ts
@@ -12,9 +12,27 @@ describe('/POST patreon', () => {
         assert.notStrictEqual(res, null)
         assert.ok(Array.isArray(res!.embeds))
         assert.strictEqual(res!.embeds.length, 1)
+        assert.equal(res!.embeds[0].title, 'Pledged $1.50')
+        assert.equal(res!.embeds[0].url, 'https://www.patreon.com/thecampaign')
+        assert.deepEqual(res!.embeds[0].author, {
+            name: 'Patreon User',
+            icon_url:
+                'https://c10.patreonusercontent.com/3/eyJ3IjoyMDB9/patreon-media/p/user/7070707/796849be3e5f406ca6391995d5985694/1.png?token-time=2145916800&token-hash=F9l2cZHAFSer14-CuPwaY0gEnbZ4m-dRlROCKMwZe5g%3D',
+            url: 'https://www.patreon.com/patreonuser',
+        })
+        assert.deepEqual(res!.embeds[0].fields, [
+            {
+                name: 'Unlocked Tier',
+                value: '[Patron on Discord ($1.00+/mo)](https://www.patreon.com/join/thecampaign/checkout?rid=5050505)\n﻿    • Earn the **Patron** rank on our [Discord Server](https://discord.gg/abcdefg).\n',
+                inline: false,
+            },
+        ])
     })
 
-    it('members:update', async () => {
+    it('members:create preserves the current v2 output', async () => {
+        const deprecatedPayload = await Tester.test(new Patreon(), 'patreon-pledge-create.json', {
+            'x-patreon-event': 'pledges:create',
+        })
         const headers = {
             'x-patreon-event': 'members:create',
         }
@@ -22,5 +40,6 @@ describe('/POST patreon', () => {
         assert.notStrictEqual(res, null)
         assert.ok(Array.isArray(res!.embeds))
         assert.strictEqual(res!.embeds.length, 1)
+        assert.deepEqual(res, deprecatedPayload)
     })
 })

--- a/test/provider/base-provider-spec.ts
+++ b/test/provider/base-provider-spec.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { DirectParseProvider } from '../../src/provider/BaseProvider.ts'
+import { Rollbar } from '../../src/provider/Rollbar.ts'
+
+const delay = (milliseconds: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, milliseconds)
+    })
+
+class DelayedProvider extends DirectParseProvider {
+    public completed = false
+
+    public getName(): string {
+        return 'Delayed'
+    }
+
+    public async parseData(): Promise<void> {
+        await delay(10)
+        this.completed = true
+        this.payload.content = 'complete'
+    }
+}
+
+class LifecycleProvider extends DirectParseProvider {
+    public readonly lifecycle: string[] = []
+
+    public getName(): string {
+        return 'Lifecycle'
+    }
+
+    protected async preParse(): Promise<void> {
+        await delay(5)
+        this.lifecycle.push('preParse')
+    }
+
+    public async parseData(): Promise<void> {
+        this.lifecycle.push('parseData')
+    }
+
+    protected async postParse(): Promise<void> {
+        await delay(5)
+        this.lifecycle.push('postParse')
+    }
+}
+
+class NullifyingProvider extends DirectParseProvider {
+    public postParseCalled = false
+
+    public getName(): string {
+        return 'Nullifying'
+    }
+
+    public async parseData(): Promise<void> {
+        this.nullifyPayload()
+    }
+
+    protected postParse(): void {
+        this.postParseCalled = true
+    }
+
+    public addEmbedAfterCancellation(): number {
+        this.addEmbed({ title: 'must not be added' })
+        return this.payload.embeds?.length ?? 0
+    }
+}
+
+describe('BaseProvider parsing lifecycle', () => {
+    it('waits for delayed direct parsing before resolving', async () => {
+        const provider = new DelayedProvider()
+
+        const result = await provider.parse(null)
+
+        assert.strictEqual(provider.completed, true)
+        assert.strictEqual(result?.content, 'complete')
+    })
+
+    it('awaits preParse, parseData, and postParse in lifecycle order', async () => {
+        const provider = new LifecycleProvider()
+
+        await provider.parse(null)
+
+        assert.deepStrictEqual(provider.lifecycle, ['preParse', 'parseData', 'postParse'])
+    })
+
+    it('returns null, skips postParse, and prevents embeds after nullification', async () => {
+        const provider = new NullifyingProvider()
+
+        const result = await provider.parse(null)
+
+        assert.strictEqual(result, null)
+        assert.doesNotThrow(() => {
+            assert.strictEqual(provider.addEmbedAfterCancellation(), 0)
+        })
+        assert.strictEqual(provider.postParseCalled, false)
+    })
+
+    it('returns null without throwing for an unknown Rollbar event', async () => {
+        const result = await new Rollbar().parse({ event_name: 'unknown_event' })
+
+        assert.strictEqual(result, null)
+    })
+})

--- a/test/provider/provider-registry-spec.ts
+++ b/test/provider/provider-registry-spec.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { DirectParseProvider } from '../../src/provider/BaseProvider.ts'
+import { type ProviderDefinition, ProviderRegistry, providerRegistry } from '../../src/provider/ProviderRegistry.ts'
+
+class DuplicatePathProvider extends DirectParseProvider {
+    public getName(): string {
+        return 'Duplicate Path'
+    }
+
+    public getPath(): string {
+        return 'duplicate'
+    }
+
+    public async parseData(): Promise<void> {
+        this.payload.content = 'duplicate'
+    }
+}
+
+const duplicateDefinition = (): ProviderDefinition => ({
+    path: 'duplicate',
+    name: 'Duplicate Path',
+    provider: DuplicatePathProvider,
+    example: { body: 'gitlab/gitlab.json' },
+})
+
+const expectedMetadata = [
+    { path: 'appcenter', name: 'AppCenter', example: { body: 'appcenter/appcenter-pipeline.json' } },
+    { path: 'appveyor', name: 'AppVeyor', example: { body: 'appveyor/appveyor.json' } },
+    { path: 'basecamp', name: 'Basecamp', example: { body: 'basecamp/basecamp.json' } },
+    {
+        path: 'bitbucket',
+        name: 'BitBucket',
+        example: { body: 'bitbucket/bitbucket.json', headers: 'bitbucket/bitbucket.headers.json' },
+    },
+    {
+        path: 'bitbucketserver',
+        name: 'BitBucketServer',
+        example: {
+            body: 'bitbucketserver/bitbucketserver.json',
+            headers: 'bitbucketserver/bitbucketserver.headers.json',
+        },
+    },
+    { path: 'circleci', name: 'CircleCi', example: { body: 'circleci/circleci.json' } },
+    { path: 'codacy', name: 'Codacy', example: { body: 'codacy/codacy.json' } },
+    { path: 'confluence', name: 'Confluence', example: { body: 'confluence/confluence_page.json' } },
+    { path: 'dockerhub', name: 'DockerHub', example: { body: 'dockerhub/dockerhub.json' } },
+    { path: 'gitlab', name: 'GitLab', example: { body: 'gitlab/gitlab.json' } },
+    { path: 'heroku', name: 'Heroku', example: { body: 'heroku/heroku.json' } },
+    { path: 'huggingface', name: 'Hugging Face', example: { body: 'huggingface/huggingface.json' } },
+    { path: 'instana', name: 'Instana', example: { body: 'instana/instana.json' } },
+    { path: 'jenkins', name: 'Jenkins-CI', example: { body: 'jenkins/jenkins.json' } },
+    { path: 'jira', name: 'Jira', example: { body: 'jira/jira-issue.json' } },
+    { path: 'newrelic', name: 'New Relic', example: { body: 'newrelic/newrelic.json' } },
+    {
+        path: 'patreon',
+        name: 'Patreon',
+        example: { body: 'patreon/patreon-member-create.json', headers: 'patreon/patreon.headers.json' },
+    },
+    { path: 'pingdom', name: 'Pingdom', example: { body: 'pingdom/pingdom.json' } },
+    { path: 'rollbar', name: 'Rollbar', example: { body: 'rollbar/rollbar.json' } },
+    {
+        path: 'shopify',
+        name: 'Shopify',
+        example: { body: 'shopify/shopify.json', headers: 'shopify/shopify.headers.json' },
+    },
+    { path: 'travis', name: 'Travis', example: { body: 'travis/travis.json' } },
+    { path: 'trello', name: 'Trello', example: { body: 'trello/trello.json' } },
+    { path: 'unity', name: 'Unity Cloud', example: { body: 'unity/unity.json' } },
+    { path: 'uptimerobot', name: 'Uptime Robot', example: { body: 'uptimerobot/uptimerobot.json' } },
+    { path: 'vsts', name: 'VSTS', example: { body: 'vsts/vsts.json' } },
+    { path: 'zendesk', name: 'Zendesk', example: { body: 'zendesk/zendesk.json' } },
+]
+
+describe('ProviderRegistry', () => {
+    it('rejects duplicate public provider paths instead of overwriting them', () => {
+        assert.throws(
+            () => new ProviderRegistry([duplicateDefinition(), duplicateDefinition()]),
+            /Duplicate provider path "duplicate"/,
+        )
+    })
+
+    it('rejects registry metadata that disagrees with the provider contract', () => {
+        assert.throws(
+            () => new ProviderRegistry([{ ...duplicateDefinition(), path: 'wrong-path' }]),
+            /Provider path "wrong-path" does not match "duplicate"/,
+        )
+        assert.throws(
+            () => new ProviderRegistry([{ ...duplicateDefinition(), name: 'Wrong Name' }]),
+            /Provider name "Wrong Name" does not match "Duplicate Path"/,
+        )
+    })
+
+    it('preserves provider order, public metadata, and example file mappings', () => {
+        assert.deepEqual(
+            providerRegistry.definitions.map(({ path, name, example }) => ({ path, name, example })),
+            expectedMetadata,
+        )
+        assert.deepEqual(
+            providerRegistry.providerInfos,
+            expectedMetadata.map(({ name, path }) => ({ name, path })),
+        )
+    })
+
+    it('looks providers up by their public path', () => {
+        const gitlab = providerRegistry.get('gitlab')
+
+        assert.equal(gitlab?.name, 'GitLab')
+        assert.strictEqual(gitlab, providerRegistry.definitions[9])
+        assert.equal(providerRegistry.get('not-registered'), undefined)
+    })
+})

--- a/test/provider/provider-runner-spec.ts
+++ b/test/provider/provider-runner-spec.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict'
+import { beforeEach, describe, it } from 'node:test'
+import type { DiscordPayload } from '../../src/model/DiscordApi.ts'
+import { loadProviderExample } from '../../src/ProviderExamples.ts'
+import { DirectParseProvider } from '../../src/provider/BaseProvider.ts'
+import { type ProviderDefinition, ProviderRegistry } from '../../src/provider/ProviderRegistry.ts'
+import { ProviderRunner } from '../../src/provider/ProviderRunner.ts'
+
+const delay = (milliseconds: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, milliseconds)
+    })
+
+class RunnerProvider extends DirectParseProvider {
+    public static constructions = 0
+    public static completions = 0
+    private readonly instanceNumber = ++RunnerProvider.constructions
+
+    public getName(): string {
+        return 'Runner'
+    }
+
+    public getPath(): string {
+        return 'runner'
+    }
+
+    public async parseData(): Promise<void> {
+        await delay(5)
+        RunnerProvider.completions += 1
+        if (this.body.ignore === true) {
+            this.nullifyPayload()
+            return
+        }
+        this.payload.content = `instance-${this.instanceNumber}:${this.body.value ?? 'complete'}`
+    }
+}
+
+class InvalidPayloadProvider extends DirectParseProvider {
+    public getName(): string {
+        return 'Invalid Payload'
+    }
+
+    public getPath(): string {
+        return 'invalid'
+    }
+
+    public async parseData(): Promise<void> {
+        this.payload.content = 'x'.repeat(2001)
+    }
+}
+
+const runnerDefinition: ProviderDefinition = {
+    path: 'runner',
+    name: 'Runner',
+    provider: RunnerProvider,
+    example: { body: 'gitlab/gitlab.json' },
+}
+
+function createRunnerRegistry(): ProviderRegistry {
+    const registry = new ProviderRegistry([runnerDefinition])
+    // Registry construction validates metadata with a temporary provider. Request
+    // construction counts start after that startup-only contract check.
+    RunnerProvider.constructions = 0
+    return registry
+}
+
+beforeEach(() => {
+    RunnerProvider.constructions = 0
+    RunnerProvider.completions = 0
+})
+
+describe('ProviderRunner', () => {
+    it('awaits asynchronous provider parsing before returning', async () => {
+        const runner = new ProviderRunner(createRunnerRegistry())
+
+        const payload = await runner.run('runner', { body: { value: 'finished' } })
+
+        assert.equal(RunnerProvider.completions, 1)
+        assert.equal(payload?.content, 'instance-1:finished')
+    })
+
+    it('constructs a fresh provider for every execution', async () => {
+        const runner = new ProviderRunner(createRunnerRegistry())
+
+        const first = await runner.run('runner', { body: { value: 'first' } })
+        const second = await runner.run('runner', { body: { value: 'second' } })
+
+        assert.equal(first?.content, 'instance-1:first')
+        assert.equal(second?.content, 'instance-2:second')
+        assert.equal(RunnerProvider.constructions, 2)
+    })
+
+    it('preserves null for ignored or unsupported events', async () => {
+        const runner = new ProviderRunner(createRunnerRegistry())
+
+        const payload = await runner.run('runner', { body: { ignore: true } })
+
+        assert.equal(payload, null)
+    })
+
+    it('uses the same execution path for live input and registered examples', async () => {
+        const registry = createRunnerRegistry()
+        const runner = new ProviderRunner(registry)
+        const example = loadProviderExample('runner', registry)
+
+        const livePayload = await runner.run('runner', example)
+        const examplePayload = await runner.runExample('runner')
+
+        assert.equal(livePayload?.content, 'instance-1:complete')
+        assert.equal(examplePayload?.content, 'instance-2:complete')
+    })
+
+    it('reports validation issues as structured warnings without mutating or rejecting output', async () => {
+        const definition: ProviderDefinition = {
+            path: 'invalid',
+            name: 'Invalid Payload',
+            provider: InvalidPayloadProvider,
+            example: { body: 'gitlab/gitlab.json' },
+        }
+        const warnings: unknown[] = []
+        const runner = new ProviderRunner(new ProviderRegistry([definition]), {
+            warn: (warning: unknown) => warnings.push(warning),
+        })
+        const expected: DiscordPayload = { content: 'x'.repeat(2001) }
+
+        const payload = await runner.run('invalid', { body: {} })
+
+        assert.deepEqual(payload, expected)
+        assert.equal(warnings.length, 1)
+        const warning = JSON.parse(String(warnings[0]))
+        assert.equal(warning.event, 'discord_payload_validation_warning')
+        assert.equal(warning.provider, 'invalid')
+        assert.deepEqual(warning.issues, [{ code: 'content-length', path: 'content', actual: 2001, limit: 2000 }])
+    })
+})

--- a/test/trello/trello-spec.ts
+++ b/test/trello/trello-spec.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
+import { afterEach, describe, it, mock } from 'node:test'
 import { Trello } from '../../src/provider/Trello.ts'
 import { Tester } from '../Tester.ts'
+
+afterEach(() => mock.restoreAll())
 
 describe('/POST trello', () => {
     it('commentCard', async () => {
@@ -9,5 +11,77 @@ describe('/POST trello', () => {
         assert.notStrictEqual(res, null)
         assert.ok(Array.isArray(res!.embeds))
         assert.strictEqual(res!.embeds.length, 1)
+        assert.deepEqual(res!.embeds[0], {
+            author: {
+                name: 'Daniel Scalzi',
+                icon_url: 'https://trello-avatars.s3.amazonaws.com/1a36134efab762cad3aadd250440b715/170.png',
+                url: 'https://trello.com/danielscalzi',
+            },
+            color: 0xb04632,
+            title: '[Example Board] Commented on Card "Example Card"',
+            url: 'https://trello.com/c/Hz7qP25x/20-example-card#comment-5946eae0be7d3669fc554adf',
+            description: '**Example Comment**\n\nThis is an example comment.',
+            footer: {
+                text: 'Powered by skyhookapi.com',
+                icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+            },
+        })
     })
+
+    for (const [eventType, action, mark] of [
+        ['enable_plugin', 'Enabled', '✓'],
+        ['disable_plugin', 'Disabled', '✗'],
+    ] as const) {
+        it(`${eventType} preserves output and bounds manifest loading`, async () => {
+            let manifestSignal: AbortSignal | null | undefined
+            mock.method(globalThis, 'fetch', async (_input: string | URL | Request, init?: RequestInit) => {
+                manifestSignal = init?.signal
+                return new Response(
+                    JSON.stringify({
+                        name: 'Calendar',
+                        details: 'Plugin details',
+                        icon: { url: '/calendar.png' },
+                    }),
+                    { status: 200, headers: { 'content-type': 'application/json' } },
+                )
+            })
+
+            const res = await Tester.testWithBody(new Trello(), {
+                action: {
+                    type: eventType,
+                    memberCreator: {
+                        fullName: 'Ada Lovelace',
+                        avatarHash: 'avatar',
+                        username: 'ada',
+                    },
+                    data: {
+                        board: { name: 'Example Board', shortLink: 'board' },
+                        plugin: {
+                            name: 'Calendar fallback',
+                            url: 'https://plugins.example/manifest.json',
+                        },
+                    },
+                },
+                model: { prefs: { background: 'blue' } },
+            })
+
+            assert.ok(manifestSignal instanceof AbortSignal)
+            assert.deepEqual(res?.embeds?.[0], {
+                author: {
+                    name: 'Ada Lovelace',
+                    icon_url: 'https://trello-avatars.s3.amazonaws.com/avatar/170.png',
+                    url: 'https://trello.com/ada',
+                },
+                color: 0x0079bf,
+                url: 'https://trello.com/b/board/example-board',
+                title: `[Example Board] ${action} Plugin ${mark}`,
+                fields: [{ name: 'Calendar', value: 'Plugin details', inline: false }],
+                image: { url: 'https://plugins.example/calendar.png' },
+                footer: {
+                    text: 'Powered by skyhookapi.com',
+                    icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+                },
+            })
+        })
+    }
 })

--- a/test/util/discord-embed-spec.ts
+++ b/test/util/discord-embed-spec.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { Embed, EmbedField } from '../../src/model/DiscordApi.ts'
+import {
+    DISCORD_EMBED_LIMITS,
+    DISCORD_MESSAGE_LIMITS,
+    fitLiteralEmbedFields,
+    SKYHOOK_FOOTER,
+    SKYHOOK_FOOTER_TEXT,
+} from '../../src/util/DiscordEmbed.ts'
+
+describe('DiscordEmbed', () => {
+    it('exposes the Discord limits and footer text used by bounded provider embeds', () => {
+        assert.deepEqual(DISCORD_MESSAGE_LIMITS, {
+            content: 2000,
+            embeds: 10,
+            embedCharacters: 6000,
+        })
+        assert.deepEqual(DISCORD_EMBED_LIMITS, {
+            title: 256,
+            description: 4096,
+            fieldName: 256,
+            fieldValue: 1024,
+            authorName: 256,
+            footerText: 2048,
+            fields: 25,
+        })
+        assert.equal(SKYHOOK_FOOTER_TEXT, 'Powered by skyhookapi.com')
+        assert.deepEqual(SKYHOOK_FOOTER, {
+            text: 'Powered by skyhookapi.com',
+            icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+        })
+    })
+
+    describe('fitLiteralEmbedFields', () => {
+        it('escapes literal field text, preserves inline policy, and skips empty fields', () => {
+            const candidates: EmbedField[] = [
+                { name: '\u0000', value: 'ignored', inline: false },
+                { name: '**Name**', value: '[value](https://example.com)', inline: true },
+                { name: 'Empty value', value: '\u0000', inline: false },
+            ]
+
+            assert.deepEqual(fitLiteralEmbedFields({}, candidates), [
+                {
+                    name: '\\*\\*Name\\*\\*',
+                    value: '\\[value\\]\\(https://example.com\\)',
+                    inline: true,
+                },
+            ])
+        })
+
+        it('enforces field count and individual field limits after escaping', () => {
+            const candidates: EmbedField[] = [
+                { name: '*'.repeat(300), value: '('.repeat(2000), inline: false },
+                ...Array.from({ length: 29 }, (_, index) => ({ name: `Field ${index}`, value: 'Value' })),
+            ]
+
+            const fields = fitLiteralEmbedFields({}, candidates)
+
+            assert.equal(fields.length, DISCORD_EMBED_LIMITS.fields)
+            assert.equal(fields[0].name.length, DISCORD_EMBED_LIMITS.fieldName)
+            assert.equal(fields[0].value.length, DISCORD_EMBED_LIMITS.fieldValue)
+            assert.ok(fields[0].name.endsWith('…'))
+            assert.ok(fields[0].value.endsWith('…'))
+        })
+
+        it('accounts for the existing embed text and default footer in the total character budget', () => {
+            const name = 'Field'
+            const embed: Embed = {
+                title: 't'.repeat(
+                    DISCORD_MESSAGE_LIMITS.embedCharacters - SKYHOOK_FOOTER_TEXT.length - name.length - 5,
+                ),
+            }
+
+            assert.deepEqual(fitLiteralEmbedFields(embed, [{ name, value: 'x'.repeat(20) }]), [
+                { name, value: 'xxxx…', inline: undefined },
+            ])
+        })
+
+        it('accepts an explicit footer text for the total character budget', () => {
+            const footerText = 'Custom footer'
+            const name = 'Field'
+            const embed: Embed = {
+                description: 'd'.repeat(DISCORD_MESSAGE_LIMITS.embedCharacters - footerText.length - name.length - 3),
+            }
+
+            assert.deepEqual(fitLiteralEmbedFields(embed, [{ name, value: 'abcdef' }], { footerText }), [
+                { name, value: 'ab…', inline: undefined },
+            ])
+        })
+    })
+})

--- a/test/util/discord-payload-validator-spec.ts
+++ b/test/util/discord-payload-validator-spec.ts
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { validateDiscordPayload } from '../../src/util/DiscordPayloadValidator.ts'
+
+const issueCodes = (payload: unknown): string[] => validateDiscordPayload(payload).map((issue) => issue.code)
+
+describe('validateDiscordPayload', () => {
+    it('accepts a payload on every Discord boundary without mutating it', () => {
+        const payload = {
+            content: 'c'.repeat(2000),
+            embeds: [
+                {
+                    title: 't'.repeat(256),
+                    description: 'd'.repeat(4096),
+                    author: { name: 'a'.repeat(256) },
+                    footer: { text: 'f'.repeat(2048) },
+                    fields: [{ name: 'n'.repeat(256), value: 'v'.repeat(1024) }],
+                },
+            ],
+        }
+        const before = structuredClone(payload)
+
+        const issues = validateDiscordPayload(payload)
+
+        assert.deepEqual(
+            issues.map((issue) => issue.code),
+            ['embed-total-characters'],
+        )
+        assert.deepEqual(payload, before)
+    })
+
+    it('reports invalid payload, content, and embeds shapes', () => {
+        assert.deepEqual(issueCodes(null), ['payload-type'])
+        assert.deepEqual(issueCodes({ content: 42 }), ['content-type'])
+        assert.deepEqual(issueCodes({ embeds: {} }), ['embeds-type'])
+    })
+
+    it('reports null content when the optional property is present', () => {
+        assert.deepEqual(validateDiscordPayload({ content: null }), [{ code: 'content-type', path: 'content' }])
+    })
+
+    it('reports null embeds when the optional property is present', () => {
+        assert.deepEqual(validateDiscordPayload({ embeds: null }), [{ code: 'embeds-type', path: 'embeds' }])
+    })
+
+    it('reports null optional embed text with precise paths', () => {
+        const issues = validateDiscordPayload({ embeds: [{ title: null, description: null }] })
+
+        assert.deepEqual(
+            issues.map(({ code, path }) => ({ code, path })),
+            [
+                { code: 'embed-title-type', path: 'embeds[0].title' },
+                { code: 'embed-description-type', path: 'embeds[0].description' },
+            ],
+        )
+    })
+
+    it('requires author names and footer text when their containers are present', () => {
+        const issues = validateDiscordPayload({ embeds: [{ author: {}, footer: {} }] })
+
+        assert.deepEqual(
+            issues.map(({ code, path }) => ({ code, path })),
+            [
+                { code: 'embed-author-name-type', path: 'embeds[0].author.name' },
+                { code: 'embed-footer-text-type', path: 'embeds[0].footer.text' },
+            ],
+        )
+    })
+
+    it('reports null optional embed containers with precise paths', () => {
+        const issues = validateDiscordPayload({ embeds: [{ author: null, footer: null, fields: null }] })
+
+        assert.deepEqual(
+            issues.map(({ code, path }) => ({ code, path })),
+            [
+                { code: 'embed-author-type', path: 'embeds[0].author' },
+                { code: 'embed-footer-type', path: 'embeds[0].footer' },
+                { code: 'embed-fields-type', path: 'embeds[0].fields' },
+            ],
+        )
+    })
+
+    it('requires string names and values for every embed field', () => {
+        const issues = validateDiscordPayload({ embeds: [{ fields: [{}, { name: null, value: null }] }] })
+
+        assert.deepEqual(
+            issues.map(({ code, path }) => ({ code, path })),
+            [
+                { code: 'embed-field-name-type', path: 'embeds[0].fields[0].name' },
+                { code: 'embed-field-value-type', path: 'embeds[0].fields[0].value' },
+                { code: 'embed-field-name-type', path: 'embeds[0].fields[1].name' },
+                { code: 'embed-field-value-type', path: 'embeds[0].fields[1].value' },
+            ],
+        )
+    })
+
+    it('reports content and embed-count limits', () => {
+        assert.ok(issueCodes({ content: 'x'.repeat(2001) }).includes('content-length'))
+        assert.ok(issueCodes({ embeds: Array.from({ length: 11 }, () => ({})) }).includes('embed-count'))
+    })
+
+    it('reports every individual embed limit', () => {
+        const fields = Array.from({ length: 26 }, (_, index) => ({
+            name: index === 0 ? 'n'.repeat(257) : 'name',
+            value: index === 0 ? 'v'.repeat(1025) : 'value',
+        }))
+        const codes = issueCodes({
+            embeds: [
+                {
+                    title: 't'.repeat(257),
+                    description: 'd'.repeat(4097),
+                    author: { name: 'a'.repeat(257) },
+                    footer: { text: 'f'.repeat(2049) },
+                    fields,
+                },
+            ],
+        })
+
+        for (const code of [
+            'embed-title-length',
+            'embed-description-length',
+            'embed-author-name-length',
+            'embed-footer-text-length',
+            'embed-field-count',
+            'embed-field-name-length',
+            'embed-field-value-length',
+            'embed-total-characters',
+        ]) {
+            assert.ok(codes.includes(code), code)
+        }
+    })
+
+    it('reports the 6000-character total across all embeds in the message', () => {
+        const codes = issueCodes({
+            embeds: [{ description: 'a'.repeat(3000) }, { description: 'b'.repeat(3001) }],
+        })
+
+        assert.deepEqual(codes, ['embed-total-characters'])
+    })
+
+    it('counts author names toward the message-wide embed character total', () => {
+        const codes = issueCodes({
+            embeds: [{ description: 'd'.repeat(4096), footer: { text: 'f'.repeat(1904) }, author: { name: 'a' } }],
+        })
+
+        assert.deepEqual(codes, ['embed-total-characters'])
+    })
+
+    it('reports non-string embed text and field values with precise paths', () => {
+        const issues = validateDiscordPayload({
+            embeds: [
+                {
+                    title: 1,
+                    author: { name: false },
+                    footer: { text: 2 },
+                    fields: [{ name: 'Count', value: 3 }],
+                },
+            ],
+        })
+
+        assert.deepEqual(
+            issues.map(({ code, path }) => ({ code, path })),
+            [
+                { code: 'embed-title-type', path: 'embeds[0].title' },
+                { code: 'embed-author-name-type', path: 'embeds[0].author.name' },
+                { code: 'embed-footer-text-type', path: 'embeds[0].footer.text' },
+                { code: 'embed-field-value-type', path: 'embeds[0].fields[0].value' },
+            ],
+        )
+    })
+})

--- a/test/util/discord-text-spec.ts
+++ b/test/util/discord-text-spec.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { cleanText, escapeDiscordMarkdownLiteral, humanizeWords, truncateText } from '../../src/util/DiscordText.ts'
+
+describe('DiscordText', () => {
+    describe('cleanText', () => {
+        it('normalizes newlines and removes unsupported control characters', () => {
+            assert.equal(cleanText(' \u0000alpha\r\nbeta\r\tgamma\u007f ', false), 'alpha\nbeta\n\tgamma')
+        })
+
+        it('collapses whitespace for single-line text', () => {
+            assert.equal(cleanText(' \tAlpha\r\n beta  \n gamma ', true), 'Alpha beta gamma')
+        })
+    })
+
+    describe('truncateText', () => {
+        it('cleans text before adding a length-bounded ellipsis', () => {
+            assert.equal(truncateText('  abc\r\ndef  ', 6, false), 'abc\nd…')
+            assert.equal(truncateText('  short  ', 10, true), 'short')
+        })
+
+        it('handles zero- and one-character limits', () => {
+            assert.equal(truncateText('long', 1, true), '…')
+            assert.equal(truncateText('long', 0, true), '')
+        })
+    })
+
+    describe('escapeDiscordMarkdownLiteral', () => {
+        it('escapes every Discord Markdown metacharacter', () => {
+            for (const character of [
+                '\\',
+                '`',
+                '*',
+                '_',
+                '{',
+                '}',
+                '[',
+                ']',
+                '(',
+                ')',
+                '<',
+                '>',
+                '#',
+                '+',
+                '!',
+                '|',
+                '~',
+            ]) {
+                assert.equal(escapeDiscordMarkdownLiteral(character), `\\${character}`)
+            }
+        })
+
+        it('leaves ordinary text and mention text unchanged', () => {
+            assert.equal(escapeDiscordMarkdownLiteral('@everyone plain-text'), '@everyone plain-text')
+        })
+    })
+
+    describe('humanizeWords', () => {
+        it('turns separated words into a sentence-cased label', () => {
+            assert.equal(humanizeWords('  CUSTOMER.account-status  '), 'Customer account status')
+            assert.equal(humanizeWords('already spaced'), 'Already spaced')
+        })
+    })
+})

--- a/test/util/error-util-spec.ts
+++ b/test/util/error-util-spec.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { ErrorUtil } from '../../src/util/ErrorUtil.ts'
+
+describe('ErrorUtil', () => {
+    it('creates a Discord-facing parse error without exception, stack, or request details', () => {
+        const error = new Error('database exception exposed super-secret-token')
+        error.stack = [
+            'Error: database exception exposed super-secret-token',
+            '    at Shopify.parse (/srv/skyhook/src/provider/Shopify.ts:42:10)',
+            'Request payload: {"access_token":"request-secret"}',
+        ].join('\n')
+
+        const payload = ErrorUtil.createErrorPayload('shopify', error)
+        const serialized = JSON.stringify(payload)
+
+        assert.equal(payload.embeds?.[0]?.title, 'Skyhook Error')
+        assert.equal(payload.embeds?.[0]?.url, 'https://github.com/Commit451/skyhook/issues')
+        assert.match(payload.embeds?.[0]?.description ?? '', /shopify/)
+        assert.doesNotMatch(serialized, /database exception/i)
+        assert.doesNotMatch(serialized, /super-secret-token/)
+        assert.doesNotMatch(serialized, /Shopify\.parse/)
+        assert.doesNotMatch(serialized, /request-secret/)
+        assert.doesNotMatch(serialized, /src\/provider/)
+    })
+})

--- a/test/util/webhook-value-spec.ts
+++ b/test/util/webhook-value-spec.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { canonicalizeIso8601Timestamp, isRecord } from '../../src/util/WebhookValue.ts'
+
+describe('WebhookValue', () => {
+    describe('isRecord', () => {
+        it('accepts non-null, non-array objects only', () => {
+            assert.equal(isRecord({}), true)
+            assert.equal(isRecord(Object.create(null)), true)
+            assert.equal(isRecord(new Date(0)), true)
+            assert.equal(isRecord(null), false)
+            assert.equal(isRecord([]), false)
+            assert.equal(isRecord('value'), false)
+            assert.equal(isRecord(1), false)
+        })
+    })
+
+    describe('canonicalizeIso8601Timestamp', () => {
+        it('canonicalizes UTC timestamps and truncates fractional seconds to milliseconds', () => {
+            assert.equal(canonicalizeIso8601Timestamp('2025-01-10T17:27:48.105316520Z'), '2025-01-10T17:27:48.105Z')
+            assert.equal(canonicalizeIso8601Timestamp('2025-01-10T17:27:48.1Z'), '2025-01-10T17:27:48.100Z')
+        })
+
+        it('canonicalizes timestamps with numeric offsets to UTC', () => {
+            assert.equal(canonicalizeIso8601Timestamp('2021-12-31T19:00:00-05:00'), '2022-01-01T00:00:00.000Z')
+            assert.equal(canonicalizeIso8601Timestamp('2025-01-08T10:12:07+02:30'), '2025-01-08T07:42:07.000Z')
+        })
+
+        it('rejects non-string and non-canonical timestamp shapes', () => {
+            for (const value of [
+                null,
+                0,
+                '2025-01-08',
+                '2025-01-08 10:12:07Z',
+                '2025-01-08T10:12Z',
+                '2025-01-08T10:12:07z',
+                '2025-01-08T10:12:07',
+                '2025-01-08T10:12:07.1234567890Z',
+            ]) {
+                assert.equal(canonicalizeIso8601Timestamp(value), null)
+            }
+        })
+
+        it('rejects impossible dates, times, and numeric offsets', () => {
+            for (const value of [
+                '2025-02-29T00:00:00Z',
+                '2025-02-31T00:00:00Z',
+                '2025-13-01T00:00:00Z',
+                '2025-01-01T24:00:00Z',
+                '2025-01-01T00:60:00Z',
+                '2025-01-01T00:00:60Z',
+                '2025-01-01T00:00:00+24:00',
+                '2025-01-01T00:00:00+00:60',
+            ]) {
+                assert.equal(canonicalizeIso8601Timestamp(value), null)
+            }
+        })
+    })
+})

--- a/test/vsts/vsts-spec.ts
+++ b/test/vsts/vsts-spec.ts
@@ -10,4 +10,52 @@ describe('/POST vsts', () => {
         assert.ok(Array.isArray(res!.embeds))
         assert.strictEqual(res!.embeds.length, 1)
     })
+
+    const pullRequestCases = [
+        ['git.pullrequest.created', 'Pull Request from Ada Lovelace'],
+        ['git.pullrequest.merged', 'Pull Request Merge Commit from Ada Lovelace'],
+        ['git.pullrequest.updated', 'Pull Request Updated by Ada Lovelace'],
+    ] as const
+
+    for (const [eventType, fieldName] of pullRequestCases) {
+        it(`preserves the ${eventType} pull-request payload`, async () => {
+            const res = await Tester.testWithBody(new VSTS(), {
+                eventType,
+                message: { markdown: '**Pull request event**' },
+                resource: {
+                    title: 'Fix webhook formatting',
+                    description: 'Preserve the existing Discord payload.',
+                    createdBy: {
+                        displayName: 'Ada Lovelace',
+                        imageUrl: 'https://example.com/ada.png',
+                    },
+                    repository: { remoteUrl: 'https://example.com/project/repository' },
+                },
+            })
+
+            assert.deepEqual(res, {
+                embeds: [
+                    {
+                        author: {
+                            name: 'Ada Lovelace',
+                            icon_url: 'https://example.com/ada.png',
+                        },
+                        fields: [
+                            {
+                                name: fieldName,
+                                value: '([`Fix webhook formatting`](https://example.com/project/repository)) Preserve the existing Discord payload.',
+                                inline: false,
+                            },
+                        ],
+                        title: '**Pull request event**',
+                        footer: {
+                            text: 'Powered by skyhookapi.com',
+                            icon_url: 'https://skyhookapi.com/images/skyhook-tiny.png',
+                        },
+                        color: 0x68217a,
+                    },
+                ],
+            })
+        })
+    }
 })


### PR DESCRIPTION
## Summary

- make provider parsing fully awaited and cancellation-safe
- centralize Discord text, embed-budget, timestamp, footer, and report-only payload validation utilities
- replace duplicate live/example provider wiring with a typed registry and shared runner
- preserve all 26 provider paths, display names, ordering, and packaged example mappings
- sanitize user-visible parse and delivery errors while retaining server-side diagnostics
- strengthen provider output characterization and consolidate safe provider-local duplication
- update provider-authoring and contributing documentation for the current Node 24 architecture

## Key details

- `BaseProvider` now awaits `preParse`, parsing, and `postParse`, and stops safely after cancellation.
- `ProviderRegistry` rejects duplicate paths and metadata that disagrees with provider contracts.
- `ProviderRunner` creates a fresh provider for every request and runs live and example payloads through the same awaited path.
- Discord payload validation is non-mutating and report-only; existing payloads are never silently truncated, split, or rejected.
- The 6,000-character Discord embed budget is measured across all embeds in a message.
- Discord delivery and Trello plugin-manifest requests now have bounded timeouts.
- Parse errors sent to Discord no longer include stack traces, request bodies, or exception details.
- Codacy field values are normalized to strings, and Bitbucket Server omits an invalid undefined description.

## Compatibility

- Existing webhook paths and provider order are unchanged.
- Unsupported/ignored events still return the existing HTTP 200 unsupported-event response.
- Unknown providers remain HTTP 400; empty payloads remain HTTP 500.
- Live parse failures still attempt a Discord error delivery and return HTTP 500 after successful delivery.
- Example failures remain generic HTTP 500 responses.

## Verification

- [x] Backend tests: 134/134 passed across 45 suites
- [x] Biome: 78 files checked, no issues
- [x] `npx tsc --noEmit`
- [x] Backend production build
- [x] Web test: 1/1 passed
- [x] Astro production build: 2 pages generated
- [x] All 26 packaged provider examples delivered with zero validation warnings
- [x] `git diff --check`

## Notes

Payload validation intentionally remains report-only. Provider-specific enforcement policy—truncate, omit, split, or reject—can be selected separately without silently changing legacy webhook behavior in this refactor.
