### PR TITLE
feat: add Square webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ https://skyhookapi.com/api/webhooks/firstPartOfWebhook/secondPartOfWebhook/provi
 - [Pingdom](https://www.pingdom.com/resources/webhooks) - `/pingdom`
 - [Rollbar](https://docs.rollbar.com/docs/webhooks) - `/rollbar`
 - [Shopify](https://shopify.dev/docs/api/webhooks/latest) - `/shopify`
+- [Square](https://developer.squareup.com/docs/webhooks/overview) - `/square`
 - [Travis](https://docs.travis-ci.com/user/notifications/#Webhooks-Delivery-Format) - `/travis`
 - [Trello](https://developers.trello.com/apis/webhooks) - `/trello`
 - [Unity Cloud](https://build-api.cloud.unity3d.com/docs/1.0.0/index.html#operation-webhooks-intro) - `/unity`
@@ -64,6 +65,12 @@ https://skyhookapi.com/api/webhooks/firstPartOfWebhook/secondPartOfWebhook/provi
 Create a webhook in Linear's API settings and use the generated `/linear` URL as its endpoint. You can subscribe the webhook to all public teams or one team and select any supported resource types. Skyhook formats Linear data-change events (including issues, comments, projects, cycles, documents, initiatives, customers, and users) as well as Issue SLA and OAuth app revocation events.
 
 Linear signatures use a secret that belongs to the configured webhook. Skyhook's generated URL does not include or store that secret, so Skyhook cannot verify `Linear-Signature`; all incoming values are treated as untrusted display data and Discord mentions are disabled.
+
+### Square setup
+
+Create a subscription in the Square Developer Console and use the generated `/square` URL as its notification URL. Select any supported Square webhook events; Skyhook formats Square's common event envelope, including current and future event families, into a bounded Discord notification.
+
+Square signatures require the subscription's signature key, the exact notification URL, and the raw request body. Skyhook does not store that key and therefore cannot verify `x-square-hmacsha256-signature`; all incoming values are treated as untrusted display data and Discord mentions are disabled.
 
 ### Zendesk setup
 

--- a/examples/square/square.json
+++ b/examples/square/square.json
@@ -1,0 +1,25 @@
+{
+  "merchant_id": "{MERCHANT_ID}",
+  "type": "customer.created",
+  "event_id": "edce24d3-bf56-46b4-b5ea-40266mnaa5a84",
+  "created_at": "2021-05-17T22:46:29Z",
+  "data": {
+    "type": "customer",
+    "id": "{CUSTOMER_ID}",
+    "object": {
+      "customer": {
+        "created_at": "2021-05-17T22:46:28.856Z",
+        "creation_source": "THIRD_PARTY",
+        "email_address": "customer@mysite.com",
+        "family_name": "Customer",
+        "given_name": "MyFirst",
+        "id": "{CUSTOMER_ID}",
+        "preferences": {
+          "email_unsubscribed": false
+        },
+        "updated_at": "2021-05-17T22:46:29Z",
+        "version": 0
+      }
+    }
+  }
+}

--- a/src/provider/ProviderRegistry.ts
+++ b/src/provider/ProviderRegistry.ts
@@ -21,6 +21,7 @@ import { Patreon } from './Patreon.ts'
 import { Pingdom } from './Pingdom.ts'
 import { Rollbar } from './Rollbar.ts'
 import { Shopify } from './Shopify.ts'
+import { Square } from './Square.ts'
 import { Travis } from './Travis.ts'
 import { Trello } from './Trello.ts'
 import { Unity } from './Unity.ts'
@@ -234,6 +235,12 @@ const providerDefinitions: readonly ProviderDefinition[] = [
             body: 'shopify/shopify.json',
             headers: 'shopify/shopify.headers.json',
         },
+    },
+    {
+        path: 'square',
+        name: 'Square',
+        provider: Square,
+        example: { body: 'square/square.json' },
     },
     {
         path: 'travis',

--- a/src/provider/Square.ts
+++ b/src/provider/Square.ts
@@ -1,0 +1,215 @@
+import type { Embed, EmbedField } from '../model/DiscordApi.ts'
+import { DISCORD_EMBED_LIMITS, fitLiteralEmbedFields } from '../util/DiscordEmbed.ts'
+import { cleanText, escapeDiscordMarkdownLiteral, humanizeWords, truncateText } from '../util/DiscordText.ts'
+import { canonicalizeIso8601Timestamp, isRecord } from '../util/WebhookValue.ts'
+import { DirectParseProvider } from './BaseProvider.ts'
+
+const EVENT_TYPE_PATTERN = /^[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+$/
+const DATA_TYPE_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/
+
+/**
+ * Converts Square's common webhook envelope into a bounded Discord embed.
+ *
+ * Square signs the notification URL and exact raw request body with a subscription-specific
+ * signature key. Skyhook does not possess that key and parses the request before provider
+ * dispatch, so this provider cannot verify x-square-hmacsha256-signature. All values are
+ * therefore treated as untrusted display data.
+ *
+ * @see https://developer.squareup.com/docs/webhooks/overview
+ * @see https://developer.squareup.com/docs/webhooks/step2subscribe#format-of-an-event-notification
+ */
+export class Square extends DirectParseProvider {
+    public constructor() {
+        super()
+        this.setEmbedColor(0x006aff)
+        this.payload.username = 'Square'
+        this.payload.allowed_mentions = { parse: [] }
+    }
+
+    public getName(): string {
+        return 'Square'
+    }
+
+    public getPath(): string {
+        return 'square'
+    }
+
+    public async parseData(): Promise<void> {
+        if (!isRecord(this.body)) {
+            this.nullifyPayload()
+            return
+        }
+
+        const eventType = boundedEventType(this.body.type)
+        const eventId = boundedText(this.body.event_id, 128)
+        const merchantId = boundedText(this.body.merchant_id, 128)
+        const timestamp = canonicalizeIso8601Timestamp(this.body.created_at)
+        const data = isRecord(this.body.data) ? this.body.data : null
+        const dataType = boundedDataType(data?.type)
+        const hasDataId = data != null && Object.hasOwn(data, 'id')
+        const dataId = hasDataId ? boundedText(data.id, 512) : null
+        if (
+            eventType == null ||
+            eventId == null ||
+            merchantId == null ||
+            timestamp == null ||
+            data == null ||
+            dataType == null ||
+            (hasDataId && dataId == null)
+        ) {
+            this.nullifyPayload()
+            return
+        }
+
+        const object = findAffectedObject(data, dataType)
+        const title = createTitle(eventType, object, dataType)
+        const embed: Embed = {
+            title: truncateText(escapeDiscordMarkdownLiteral(title), DISCORD_EMBED_LIMITS.title, true),
+            timestamp,
+        }
+        embed.fields = fitLiteralEmbedFields(embed, createFields(this.body, object, dataType, dataId))
+        this.addEmbed(embed)
+    }
+}
+
+function createTitle(eventType: string, object: Record<string, any> | null, dataType: string): string {
+    const parts = eventType.split('.')
+    const action = parts.pop()!
+    const resource = humanizeSquareWords(parts.join(' '))
+    const actionLabel = humanizeSquareWords(action).toLowerCase()
+    const subject = object == null ? null : objectLabel(object, dataType)
+    return `${resource} ${actionLabel}${subject == null ? '' : `: ${subject}`}`
+}
+
+function createFields(
+    envelope: Record<string, any>,
+    object: Record<string, any> | null,
+    dataType: string,
+    dataId: string | null,
+): EmbedField[] {
+    const fields: EmbedField[] = []
+    const status = object == null ? null : firstScalar(object.status, object.state)
+    if (status != null) {
+        fields.push({ name: 'Status', value: humanizeStatus(status), inline: true })
+    }
+
+    const amount = object == null ? null : firstMoney(object)
+    if (amount != null) {
+        fields.push({ name: 'Amount', value: amount, inline: true })
+    }
+
+    addIdentifierField(fields, 'Order ID', object?.order_id)
+    addIdentifierField(fields, 'Customer ID', object?.customer_id)
+    addIdentifierField(fields, 'Location ID', envelope.location_id ?? object?.location_id)
+
+    const objectIdName = `${humanizeSquareWords(dataType)} ID`
+    if (dataId != null && !fields.some(({ name, value }) => name === objectIdName && value === dataId)) {
+        fields.push({ name: objectIdName, value: dataId, inline: true })
+    }
+    return fields
+}
+
+function addIdentifierField(fields: EmbedField[], name: string, value: unknown): void {
+    const identifier = boundedText(value, 512)
+    if (identifier != null) {
+        fields.push({ name, value: identifier, inline: true })
+    }
+}
+
+function findAffectedObject(data: Record<string, any>, dataType: string): Record<string, any> | null {
+    if (!isRecord(data.object)) {
+        return null
+    }
+    if (isRecord(data.object[dataType])) {
+        return data.object[dataType]
+    }
+
+    const recordValues = Object.values(data.object).filter(isRecord)
+    return recordValues.length === 1 ? recordValues[0] : null
+}
+
+function objectLabel(object: Record<string, any>, dataType: string): string | null {
+    if (dataType === 'customer') {
+        const customerName = [scalarText(object.given_name), scalarText(object.family_name)].filter(Boolean).join(' ')
+        if (customerName.length > 0) {
+            return customerName
+        }
+    }
+    return firstScalar(object.name, object.title, object.reference_id)
+}
+
+function firstMoney(object: Record<string, any>): string | null {
+    for (const value of [object.amount_money, object.total_money, object.total_amount_money, object.approved_money]) {
+        const formatted = formatMoney(value)
+        if (formatted != null) {
+            return formatted
+        }
+    }
+    return null
+}
+
+function formatMoney(value: unknown): string | null {
+    if (!isRecord(value) || !Number.isSafeInteger(value.amount) || !/^[A-Z]{3}$/.test(value.currency)) {
+        return null
+    }
+    try {
+        const fractionDigits =
+            new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: value.currency,
+            }).resolvedOptions().maximumFractionDigits ?? 2
+        return `${(value.amount / 10 ** fractionDigits).toFixed(fractionDigits)} ${value.currency}`
+    } catch {
+        return null
+    }
+}
+
+function boundedEventType(value: unknown): string | null {
+    const type = boundedText(value, 200)
+    return type != null && EVENT_TYPE_PATTERN.test(type) ? type : null
+}
+
+function boundedDataType(value: unknown): string | null {
+    const type = boundedText(value, 100)
+    return type != null && DATA_TYPE_PATTERN.test(type) ? type : null
+}
+
+function boundedText(value: unknown, maxLength: number): string | null {
+    if (typeof value !== 'string') {
+        return null
+    }
+    const text = cleanText(value, true)
+    return text.length > 0 && text.length <= maxLength ? text : null
+}
+
+function firstScalar(...values: unknown[]): string | null {
+    for (const value of values) {
+        const text = scalarText(value)
+        if (text != null) {
+            return text
+        }
+    }
+    return null
+}
+
+function scalarText(value: unknown): string | null {
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+        return null
+    }
+    if (
+        typeof value === 'number' &&
+        (!Number.isFinite(value) || (Number.isInteger(value) && !Number.isSafeInteger(value)))
+    ) {
+        return null
+    }
+    const text = cleanText(String(value), false)
+    return text.length > 0 ? text : null
+}
+
+function humanizeSquareWords(value: string): string {
+    return humanizeWords(value).replace(/^Oauth\b/, 'OAuth')
+}
+
+function humanizeStatus(value: string): string {
+    return /^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(value) ? humanizeSquareWords(value) : value
+}

--- a/test/examples/examples-spec.ts
+++ b/test/examples/examples-spec.ts
@@ -40,6 +40,7 @@ const expectedProviderPaths = [
     'pingdom',
     'rollbar',
     'shopify',
+    'square',
     'travis',
     'trello',
     'unity',

--- a/test/provider/provider-registry-spec.ts
+++ b/test/provider/provider-registry-spec.ts
@@ -69,6 +69,7 @@ const expectedMetadata = [
         name: 'Shopify',
         example: { body: 'shopify/shopify.json', headers: 'shopify/shopify.headers.json' },
     },
+    { path: 'square', name: 'Square', example: { body: 'square/square.json' } },
     { path: 'travis', name: 'Travis', example: { body: 'travis/travis.json' } },
     { path: 'trello', name: 'Trello', example: { body: 'trello/trello.json' } },
     { path: 'unity', name: 'Unity Cloud', example: { body: 'unity/unity.json' } },

--- a/test/square/square-spec.ts
+++ b/test/square/square-spec.ts
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { loadProviderExample } from '../../src/ProviderExamples.ts'
+import { Square } from '../../src/provider/Square.ts'
+import { Tester } from '../Tester.ts'
+
+const envelope = {
+    merchant_id: 'merchant_123',
+    event_id: 'f8f2adf4-28ea-4c06-9df0-c76f6f5c612d',
+    created_at: '2026-07-26T14:30:15.123Z',
+}
+
+describe('/POST square', () => {
+    it('exposes provider metadata', () => {
+        const provider = new Square()
+
+        assert.equal(provider.getName(), 'Square')
+        assert.equal(provider.getPath(), 'square')
+    })
+
+    it('formats the documented customer payload used by example delivery', async () => {
+        const example = loadProviderExample('square')
+        const result = await Tester.testWithBody(new Square(), example.body, example.headers, example.query)
+        assert.notEqual(result, null)
+        assert.equal(result!.username, 'Square')
+        assert.deepEqual(result!.allowed_mentions, { parse: [] })
+        assert.equal(result!.embeds?.length, 1)
+
+        const embed = result!.embeds![0]
+        assert.equal(embed.title, 'Customer created: MyFirst Customer')
+        assert.equal(embed.timestamp, '2021-05-17T22:46:29.000Z')
+        assert.equal(embed.color, 0x006aff)
+        assert.deepEqual(embed.fields, [{ name: 'Customer ID', value: '\\{CUSTOMER\\_ID\\}', inline: true }])
+        assert.doesNotMatch(JSON.stringify(result), /customer@mysite\.com/)
+    })
+
+    it('summarizes payment events with status, money, and identifiers', async () => {
+        const result = await Tester.testWithBody(new Square(), {
+            ...envelope,
+            location_id: 'location_123',
+            type: 'payment.updated',
+            data: {
+                type: 'payment',
+                id: 'payment_123',
+                object: {
+                    payment: {
+                        id: 'payment_123',
+                        status: 'COMPLETED',
+                        amount_money: { amount: 1234, currency: 'USD' },
+                        order_id: 'order_123',
+                    },
+                },
+            },
+        })
+        assert.notEqual(result, null)
+
+        const embed = result!.embeds![0]
+        assert.equal(embed.title, 'Payment updated')
+        assert.equal(embed.timestamp, '2026-07-26T14:30:15.123Z')
+        assert.deepEqual(embed.fields, [
+            { name: 'Status', value: 'Completed', inline: true },
+            { name: 'Amount', value: '12.34 USD', inline: true },
+            { name: 'Order ID', value: 'order\\_123', inline: true },
+            { name: 'Location ID', value: 'location\\_123', inline: true },
+            { name: 'Payment ID', value: 'payment\\_123', inline: true },
+        ])
+    })
+
+    it('accepts the documented mixed-case Location data type', async () => {
+        const result = await Tester.testWithBody(new Square(), {
+            ...envelope,
+            location_id: 'location_123',
+            type: 'location.created',
+            data: {
+                type: 'Location',
+                id: 'location_123',
+                object: {
+                    location: {
+                        id: 'location_123',
+                        name: 'Main **Store**',
+                        status: 'ACTIVE',
+                    },
+                },
+            },
+        })
+        assert.notEqual(result, null)
+        assert.equal(result!.embeds![0].title, 'Location created: Main \\*\\*Store\\*\\*')
+        assert.deepEqual(result!.embeds![0].fields, [
+            { name: 'Status', value: 'Active', inline: true },
+            { name: 'Location ID', value: 'location\\_123', inline: true },
+        ])
+    })
+
+    it('handles deleted objects and future event families generically', async () => {
+        const deleted = await Tester.testWithBody(new Square(), {
+            ...envelope,
+            type: 'customer.deleted',
+            data: {
+                type: 'customer',
+                id: 'customer_456',
+                deleted: true,
+            },
+        })
+        assert.notEqual(deleted, null)
+        assert.equal(deleted!.embeds![0].title, 'Customer deleted')
+        assert.deepEqual(deleted!.embeds![0].fields, [{ name: 'Customer ID', value: 'customer\\_456', inline: true }])
+
+        const future = await Tester.testWithBody(new Square(), {
+            ...envelope,
+            type: 'inventory.adjustment.flagged',
+            data: {
+                type: 'inventory_adjustment',
+                id: 'adjustment_789',
+                object: {
+                    inventory_adjustment: {
+                        name: 'Cycle **count**',
+                        status: '[blocked](https://evil.example)',
+                    },
+                },
+            },
+        })
+        assert.notEqual(future, null)
+        assert.equal(future!.embeds![0].title, 'Inventory adjustment flagged: Cycle \\*\\*count\\*\\*')
+        assert.deepEqual(future!.embeds![0].fields, [
+            {
+                name: 'Status',
+                value: '\\[blocked\\]\\(https://evil.example\\)',
+                inline: true,
+            },
+            { name: 'Inventory adjustment ID', value: 'adjustment\\_789', inline: true },
+        ])
+    })
+
+    it('accepts documented event data that has no affected object ID', async () => {
+        const catalog = await Tester.testWithBody(new Square(), {
+            ...envelope,
+            type: 'catalog.version.updated',
+            data: {
+                type: 'catalog_version',
+                object: {
+                    catalog_version: {
+                        updated_at: '2026-07-26T14:29:00Z',
+                    },
+                },
+            },
+        })
+        assert.notEqual(catalog, null)
+        assert.equal(catalog!.embeds![0].title, 'Catalog version updated')
+        assert.deepEqual(catalog!.embeds![0].fields, [])
+
+        const revoked = await Tester.testWithBody(new Square(), {
+            ...envelope,
+            type: 'oauth.authorization.revoked',
+            data: {
+                type: 'revocation',
+                object: {
+                    revocation: {
+                        revoked_at: '2026-07-26T14:29:00Z',
+                    },
+                },
+            },
+        })
+        assert.notEqual(revoked, null)
+        assert.equal(revoked!.embeds![0].title, 'OAuth authorization revoked')
+        assert.deepEqual(revoked!.embeds![0].fields, [])
+    })
+
+    it('rejects malformed webhook envelopes', async () => {
+        const valid = {
+            ...envelope,
+            type: 'customer.created',
+            data: { type: 'customer', id: 'customer_123', object: { customer: {} } },
+        }
+        for (const body of [
+            null,
+            {},
+            { ...valid, merchant_id: '' },
+            { ...valid, event_id: '' },
+            { ...valid, created_at: '2026-02-31T00:00:00Z' },
+            { ...valid, type: 'invalid' },
+            { ...valid, type: 'Customer.created' },
+            { ...valid, data: null },
+            { ...valid, data: { type: '', id: 'customer_123' } },
+            { ...valid, data: { type: 'customer', id: '' } },
+            { ...valid, data: { type: 'customer', id: null } },
+        ]) {
+            assert.equal(await Tester.testWithBody(new Square(), body), null)
+        }
+    })
+
+    it('stays within Discord limits for long untrusted object values', async () => {
+        const longText = '@everyone [click](https://evil.example) ' + 'x'.repeat(7000)
+        const result = await Tester.testWithBody(new Square(), {
+            ...envelope,
+            type: 'catalog.version.updated',
+            data: {
+                type: 'catalog_version',
+                id: 'catalog_version_123',
+                object: {
+                    catalog_version: {
+                        name: longText,
+                        status: longText,
+                        reference_id: longText,
+                    },
+                },
+            },
+        })
+        assert.notEqual(result, null)
+        assert.deepEqual(result!.allowed_mentions, { parse: [] })
+
+        const embed = result!.embeds![0]
+        assert.ok((embed.title?.length ?? 0) <= 256)
+        assert.ok((embed.description?.length ?? 0) <= 4096)
+        assert.ok((embed.fields?.length ?? 0) <= 25)
+        for (const field of embed.fields ?? []) {
+            assert.ok(field.name.length <= 256)
+            assert.ok(field.value.length <= 1024)
+        }
+        const aggregateLength =
+            (embed.title?.length ?? 0) +
+            (embed.description?.length ?? 0) +
+            (embed.author?.name.length ?? 0) +
+            (embed.footer?.text.length ?? 0) +
+            (embed.fields ?? []).reduce((total, field) => total + field.name.length + field.value.length, 0)
+        assert.ok(aggregateLength <= 6000)
+    })
+})

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -29,6 +29,7 @@ const providers: Provider[] = [
     { name: 'Pingdom', slug: 'pingdom', color: '#fce000' },
     { name: 'Rollbar', slug: 'rollbar', color: '#5c7cf5' },
     { name: 'Shopify', slug: 'shopify', color: '#95bf47' },
+    { name: 'Square', slug: 'square', color: '#006aff', monogram: 'SQ' },
     { name: 'Travis CI', slug: 'travis', color: '#3eaaaf' },
     { name: 'Trello', slug: 'trello', color: '#2684ff' },
     { name: 'Unity Cloud', slug: 'unity', color: '#e8e8e8' },
@@ -57,7 +58,7 @@ const faqs = [
     },
     {
         q: 'Which services does skyhook support?',
-        a: `${providers.length} and counting — including Shopify, Zendesk, Linear, GitLab, Hugging Face, Jira, Confluence, Bitbucket, Docker Hub, Travis CI, CircleCI, Jenkins, Heroku, New Relic, Rollbar, Pingdom, Uptime Robot, Trello, Patreon and Azure DevOps.`,
+        a: `${providers.length} and counting — including Shopify, Square, Zendesk, Linear, GitLab, Hugging Face, Jira, Confluence, Bitbucket, Docker Hub, Travis CI, CircleCI, Jenkins, Heroku, New Relic, Rollbar, Pingdom, Uptime Robot, Trello, Patreon and Azure DevOps.`,
     },
     {
         q: 'Do I need to host a bot or write any code?',

--- a/web/test/provider-order.test.mjs
+++ b/web/test/provider-order.test.mjs
@@ -23,6 +23,8 @@ test('supported providers are rendered alphabetically by display name', () => {
     assert.deepEqual(names, alphabetizedNames)
     assert.ok(names.includes('Linear'), 'Linear should appear in the supported-provider grid')
     assert.ok(existsSync(new URL('../public/providers/linear.svg', import.meta.url)), 'Linear should have a logo asset')
+    assert.ok(names.includes('Square'), 'Square should appear in the supported-provider grid')
+    assert.match(providerSection[1], /title="\/square"/, 'Square should use the /square endpoint')
     assert.ok(names.includes('Azure DevOps'), 'Azure DevOps should appear in the supported-provider grid')
     assert.match(providerSection[1], /title="\/azure"/, 'Azure DevOps should use the /azure endpoint')
     assert.doesNotMatch(providerSection[1], /title="\/vsts"/, 'the retired /vsts endpoint should not be shown')


### PR DESCRIPTION
## Summary

- add a generic Square webhook provider at `/square` with Discord-safe summaries for current and future event families
- register Square in the backend provider/example surfaces and package an official-style `customer.created` fixture
- add the Square website tile, provider count/order coverage, README setup guidance, and comprehensive provider tests

## Validation

- `npm test` — 153 tests passed
- `npm run lint`
- `npm run build`
- `cd web && npm test` — 1 test passed
- `cd web && npm run build`
- replayed all 149 webhook examples from Square's official OpenAPI specification — 0 failures
- built the production Docker image and exercised the packaged Square provider
- independent read-only review approved the final worktree with no blocker/high/medium findings

## Security notes

- all incoming Square fields are treated as untrusted: Discord Markdown is escaped, mention parsing is disabled, and embed budgets are enforced
- Square HMAC signature verification is not implemented because Skyhook's current public-relay flow does not collect each subscription's signature key or preserve a provider-specific verification context; this limitation is documented in the provider and README
- delivery deduplication by Square `event_id` remains outside the current stateless relay architecture
